### PR TITLE
Filter devices by capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Samsung WindFree AC",
   "name": "homebridge-samsung-windfree-ac",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Homebridge plugin for Samsung WindFree AC.",
   "license": "Apache-2.0",
   "private": false,

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -51,6 +51,13 @@ export class HomebridgePlatform implements DynamicPlatformPlugin {
       const capabilities = device.components[0].capabilities
         .map((capability: { id: string }) => capability.id);
 
+      this.log.debug('Discovered device:', device.label, capabilities);
+
+      if (!this.doesDeviceSupportCapabilities(capabilities)) {
+        this.log.warn('Device has unsupported capabilities:', device.label);
+        return;
+      }
+
       const existingAccessory = this.accessories.find(accessory => accessory.UUID === uuid);
 
       if (existingAccessory) {
@@ -69,5 +76,15 @@ export class HomebridgePlatform implements DynamicPlatformPlugin {
         this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
       }
     }
+  }
+
+  doesDeviceSupportCapabilities(capabilities: string[]): boolean {
+    const supportedCapabilities = AirConditionerPlatformAccessory.supportedCapabilities;
+
+    return supportedCapabilities.every(capability => {
+      this.log.debug('Checking if device supports capability:', capability);
+
+      return capabilities.includes(capability);
+    });
   }
 }

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -31,6 +31,14 @@ export class AirConditionerPlatformAccessory {
 
   private temperatureUnit: TemperatureUnit = TemperatureUnit.Celsius;
 
+  public static readonly supportedCapabilities =
+    [
+      'switch',
+      'airConditionerMode',
+      'thermostatCoolingSetpoint',
+      'custom.airConditionerOptionalMode',
+    ];
+
   protected name: string;
   protected commandURL: string;
   protected statusURL: string;


### PR DESCRIPTION
This pull request fixes an issue where devices were not being filtered by their capabilities. Now, devices that do not support the required capabilities will be ignored. This ensures that only compatible devices are added as accessories.