### PR TITLE
Update Node.js version to 22.x in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         # the Node.js versions to build on
-        node-version: [18.x, 20.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '22.x'
       - run: npm ci
       # - run: npm test
       - run: npm run build
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish


### PR DESCRIPTION
Upgrade the Node.js version in the GitHub workflows to 22.x for improved performance and compatibility.