### PR TITLE
Stabilize status reads and add OAuth2 authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,28 +26,55 @@ Simplest, but note that **PATs created after 2024-12-30 expire 24 hours after cr
 
 ### Option B — OAuth2 (recommended, renews automatically)
 
-With OAuth the plugin renews the access token on its own, so you never have to regenerate it manually.
+Because a new PAT expires after 24 hours (see Option A), OAuth2 is the only way to keep the plugin authenticated without regenerating a token every day. You create your own OAuth-In app once; the plugin then uses its refresh token to obtain and renew access tokens automatically.
 
-1. Install the [SmartThings CLI](https://github.com/SmartThingsCommunity/smartthings-cli) and create an OAuth-In app:
+#### 1. Create an OAuth-In app (one time)
 
-   ```
-   smartthings apps:create
-   ```
+Install the [SmartThings CLI](https://github.com/SmartThingsCommunity/smartthings-cli), then run:
 
-   Choose **OAuth-In App**, grant the scopes `r:devices:*` and `x:devices:*`, and set the redirect URI to a **public HTTPS URL** — SmartThings rejects `localhost`/`http` redirects with a 403. A convenient choice is `https://httpbin.org/get`, which simply echoes back the authorization code. This yields an **OAuth Client ID** and **Client Secret**.
+```
+smartthings apps:create
+```
 
-   > To change the redirect URI or scopes of an existing app: `smartthings apps:oauth:update <AppId>`.
+- Choose **OAuth-In App** (may be shown as "API-only").
+- Grant the scopes `r:devices:*` and `x:devices:*` (read + control devices).
+- Set the redirect URI to a **public HTTPS URL**. SmartThings rejects `localhost`/`http` redirect URIs with a `403 Forbidden` on the authorize endpoint, so a local callback does not work. A convenient choice is `https://httpbin.org/get`, which simply echoes back the authorization code.
 
-2. Run the one-time setup helper (on a machine with a browser). The script only uses Node built-ins, so you can download and run it directly:
+The command prints an **OAuth Client ID** and **Client Secret** (the secret is shown only once). To edit the redirect URI or scopes of an existing app later: `smartthings apps:oauth:update <AppId>`.
 
-   ```
-   curl -O https://raw.githubusercontent.com/dstmrk/homebridge-samsung-windfree-ac/main/bin/oauth-setup.mjs
-   node oauth-setup.mjs
-   ```
+#### 2. Obtain the refresh token (one time)
 
-   Paste the Client ID/Secret and the same redirect URI when prompted. Open the printed authorization URL, approve access, then copy the `code` value from the redirect page (or the browser address bar) and paste it back into the helper. It prints the `RefreshToken`.
+Do this on a machine with a browser. Pick either method.
 
-3. Put `ClientID`, `ClientSecret` and `RefreshToken` in the config and leave `AccessToken` empty. The refresh token rotates on every use and is persisted to disk automatically.
+**Method A — helper script (recommended).** Download `bin/oauth-setup.mjs` from this repository (it has no dependencies) and run it:
+
+```
+node oauth-setup.mjs
+```
+
+Paste the Client ID/Secret and the redirect URI when prompted, open the printed authorization URL, approve access, then copy the `code` from the redirect page (the `httpbin` JSON, or the browser address bar after `code=`) and paste it back. The script prints the `RefreshToken`.
+
+**Method B — manual.** Open this URL in a browser (replace `CLIENT_ID`; keep the redirect URI identical to the one registered on the app):
+
+```
+https://api.smartthings.com/oauth/authorize?client_id=CLIENT_ID&response_type=code&scope=r:devices:*%20x:devices:*&redirect_uri=https://httpbin.org/get
+```
+
+After approving, copy the `code` from the redirect and exchange it for tokens (the code is single-use and expires within minutes):
+
+```
+curl -s -u "CLIENT_ID:CLIENT_SECRET" \
+  -d grant_type=authorization_code \
+  -d code=THE_CODE \
+  -d "redirect_uri=https://httpbin.org/get" \
+  https://api.smartthings.com/oauth/token
+```
+
+Copy the `refresh_token` from the JSON response.
+
+#### 3. Configure the plugin
+
+Put `ClientID`, `ClientSecret` and `RefreshToken` in the config and leave `AccessToken` empty. The refresh token rotates on every use and the newest one is persisted to disk (in the Homebridge storage directory), so you never need to update it manually.
 
 ## Configuration
 Configuration parameters:

--- a/README.md
+++ b/README.md
@@ -34,17 +34,20 @@ With OAuth the plugin renews the access token on its own, so you never have to r
    smartthings apps:create
    ```
 
-   Choose **OAuth-In App**, set the redirect URI to `http://localhost:8000/callback`, and grant the scopes `r:devices:*` and `x:devices:*`. This yields an **OAuth Client ID** and **Client Secret**.
+   Choose **OAuth-In App**, grant the scopes `r:devices:*` and `x:devices:*`, and set the redirect URI to a **public HTTPS URL** — SmartThings rejects `localhost`/`http` redirects with a 403. A convenient choice is `https://httpbin.org/get`, which simply echoes back the authorization code. This yields an **OAuth Client ID** and **Client Secret**.
 
-2. Run the one-time setup helper to obtain the refresh token:
+   > To change the redirect URI or scopes of an existing app: `smartthings apps:oauth:update <AppId>`.
+
+2. Run the one-time setup helper (on a machine with a browser). The script only uses Node built-ins, so you can download and run it directly:
 
    ```
-   npx homebridge-samsung-windfree-ac-auth
+   curl -O https://raw.githubusercontent.com/dstmrk/homebridge-samsung-windfree-ac/main/bin/oauth-setup.mjs
+   node oauth-setup.mjs
    ```
 
-   Paste the Client ID/Secret when prompted, approve access in the browser, and copy the printed `RefreshToken`.
+   Paste the Client ID/Secret and the same redirect URI when prompted. Open the printed authorization URL, approve access, then copy the `code` value from the redirect page (or the browser address bar) and paste it back into the helper. It prints the `RefreshToken`.
 
-3. Put `ClientID`, `ClientSecret` and `RefreshToken` in the config. The refresh token rotates on every use and is persisted to disk automatically.
+3. Put `ClientID`, `ClientSecret` and `RefreshToken` in the config and leave `AccessToken` empty. The refresh token rotates on every use and is persisted to disk automatically.
 
 ## Configuration
 Configuration parameters:

--- a/README.md
+++ b/README.md
@@ -16,14 +16,47 @@ This plugin allows you to control your Samsung WindFree AC through Homebridge.
 ## Installation
 Install this plugin using: `hb-service add homebridge-samsung-windfree-ac`
 
+## Authentication
+
+You can authenticate in one of two ways.
+
+### Option A — Personal Access Token (PAT)
+
+Simplest, but note that **PATs created after 2024-12-30 expire 24 hours after creation** and cannot be extended, so you would have to regenerate the token every day. Create one on the [personal access tokens page](https://account.smartthings.com/login?redirect=https%3A%2F%2Faccount.smartthings.com%2Ftokens) (scopes: read/execute devices) and set it as `AccessToken`.
+
+### Option B — OAuth2 (recommended, renews automatically)
+
+With OAuth the plugin renews the access token on its own, so you never have to regenerate it manually.
+
+1. Install the [SmartThings CLI](https://github.com/SmartThingsCommunity/smartthings-cli) and create an OAuth-In app:
+
+   ```
+   smartthings apps:create
+   ```
+
+   Choose **OAuth-In App**, set the redirect URI to `http://localhost:8000/callback`, and grant the scopes `r:devices:*` and `x:devices:*`. This yields an **OAuth Client ID** and **Client Secret**.
+
+2. Run the one-time setup helper to obtain the refresh token:
+
+   ```
+   npx homebridge-samsung-windfree-ac-auth
+   ```
+
+   Paste the Client ID/Secret when prompted, approve access in the browser, and copy the printed `RefreshToken`.
+
+3. Put `ClientID`, `ClientSecret` and `RefreshToken` in the config. The refresh token rotates on every use and is persisted to disk automatically.
+
 ## Configuration
 Configuration parameters:
 
 - `name`: The name of the platform.
 - `BaseURL`: The base URL for the API.
-- `AccessToken`: Your access token. They can be created and managed on the [personal access tokens page.](https://account.smartthings.com/login?redirect=https%3A%2F%2Faccount.smartthings.com%2Ftokens)
+- `AccessToken`: PAT auth (Option A). Leave empty when using OAuth.
+- `ClientID` / `ClientSecret` / `RefreshToken`: OAuth auth (Option B).
+- `OptionalWindFreeSwitch`: expose a switch for WindFree mode.
+- `OptionalDisplaySwitch`: expose a switch for the display light.
 
-Here is a sample configuration:
+Sample configuration (PAT):
 
 ```json
 {
@@ -37,6 +70,31 @@ Here is a sample configuration:
     ]
 }
 ```
+
+Sample configuration (OAuth):
+
+```json
+{
+    "platforms": [
+        {
+            "platform": "Homebridge Samsung WindFree AC",
+            "name": "Samsung WindFree AC",
+            "BaseURL": "https://api.smartthings.com/v1/",
+            "ClientID": "your_oauth_client_id",
+            "ClientSecret": "your_oauth_client_secret",
+            "RefreshToken": "your_oauth_refresh_token"
+        }
+    ]
+}
+```
+
+## Notes on stability
+
+Device status is cached briefly and refreshed on a background poll, so many
+simultaneous HomeKit reads collapse into a single SmartThings request. This
+avoids the API rate limits (HTTP 429) that previously caused `Failed to get
+device status` errors. On an expired/invalid token you will see a clear HTTP
+401 message in the log instead.
 
 ## Supported Modes
 - `off`

--- a/bin/oauth-setup.mjs
+++ b/bin/oauth-setup.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+/**
+ * One-time OAuth setup helper for homebridge-samsung-windfree-ac.
+ *
+ * It walks you through the SmartThings authorization-code flow and prints the
+ * RefreshToken to paste into the plugin config. Run it on a machine with a
+ * browser reachable at http://localhost:<port>.
+ *
+ * Prerequisites: an OAuth-In app created with the SmartThings CLI, e.g.
+ *
+ *   smartthings apps:create
+ *     -> "OAuth-In App"
+ *     -> Redirect URI:   http://localhost:8000/callback
+ *     -> Scopes:         r:devices:* x:devices:*
+ *
+ * which yields the OAuth Client ID and Client Secret used below.
+ */
+
+import http from 'node:http';
+import readline from 'node:readline';
+import { URL } from 'node:url';
+
+const AUTHORIZE_URL = 'https://api.smartthings.com/oauth/authorize';
+const TOKEN_URL = 'https://api.smartthings.com/oauth/token';
+const SCOPES = ['r:devices:*', 'x:devices:*'];
+const DEFAULT_PORT = 8000;
+const CALLBACK_PATH = '/callback';
+
+function ask(rl, question, fallback) {
+  return new Promise((resolve) => {
+    const suffix = fallback ? ` [${fallback}]` : '';
+    rl.question(`${question}${suffix}: `, (answer) => {
+      const trimmed = answer.trim();
+      resolve(trimmed === '' && fallback !== undefined ? fallback : trimmed);
+    });
+  });
+}
+
+async function waitForCode(port) {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const requestUrl = new URL(req.url, `http://localhost:${port}`);
+      if (requestUrl.pathname !== CALLBACK_PATH) {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+
+      const code = requestUrl.searchParams.get('code');
+      const error = requestUrl.searchParams.get('error');
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(
+        '<html><body style="font-family:sans-serif">'
+        + (code
+          ? '<h2>Authorization complete</h2><p>You can close this tab and return to the terminal.</p>'
+          : `<h2>Authorization failed</h2><p>${error || 'No code returned.'}</p>`)
+        + '</body></html>',
+      );
+
+      server.close();
+      if (code) {
+        resolve(code);
+      } else {
+        reject(new Error(error || 'No authorization code returned'));
+      }
+    });
+
+    server.on('error', reject);
+    server.listen(port);
+  });
+}
+
+async function exchangeCode({ clientId, clientSecret, code, redirectUri }) {
+  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: clientId,
+    code,
+    redirect_uri: redirectUri,
+  });
+
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Basic ${basic}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Accept': 'application/json',
+    },
+    body: body.toString(),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Token exchange failed (HTTP ${response.status}): ${text}`);
+  }
+  return JSON.parse(text);
+}
+
+async function main() {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+  try {
+    console.log('\nSmartThings OAuth setup for homebridge-samsung-windfree-ac\n');
+
+    const clientId = await ask(rl, 'OAuth Client ID');
+    const clientSecret = await ask(rl, 'OAuth Client Secret');
+    const port = Number(await ask(rl, 'Local callback port', String(DEFAULT_PORT)));
+    const redirectUri = `http://localhost:${port}${CALLBACK_PATH}`;
+
+    if (!clientId || !clientSecret) {
+      throw new Error('Client ID and Client Secret are required.');
+    }
+
+    const authorizeUrl = new URL(AUTHORIZE_URL);
+    authorizeUrl.searchParams.set('response_type', 'code');
+    authorizeUrl.searchParams.set('client_id', clientId);
+    authorizeUrl.searchParams.set('scope', SCOPES.join(' '));
+    authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+
+    console.log('\nMake sure this exact redirect URI is registered on your OAuth app:');
+    console.log(`  ${redirectUri}\n`);
+    console.log('Open this URL in your browser and approve access:\n');
+    console.log(`  ${authorizeUrl.toString()}\n`);
+    console.log(`Waiting for the SmartThings redirect on port ${port} ...`);
+
+    const code = await waitForCode(port);
+    const tokens = await exchangeCode({ clientId, clientSecret, code, redirectUri });
+
+    console.log('\nSuccess! Add these to your plugin config (config.schema OAuth fields):\n');
+    console.log(`  "ClientID": "${clientId}",`);
+    console.log(`  "ClientSecret": "${clientSecret}",`);
+    console.log(`  "RefreshToken": "${tokens.refresh_token}"\n`);
+    console.log('The plugin renews the access token automatically from here on.');
+  } catch (error) {
+    console.error('\nSetup failed:', error.message);
+    process.exitCode = 1;
+  } finally {
+    rl.close();
+  }
+}
+
+main();

--- a/bin/oauth-setup.mjs
+++ b/bin/oauth-setup.mjs
@@ -4,28 +4,32 @@
  * One-time OAuth setup helper for homebridge-samsung-windfree-ac.
  *
  * It walks you through the SmartThings authorization-code flow and prints the
- * RefreshToken to paste into the plugin config. Run it on a machine with a
- * browser reachable at http://localhost:<port>.
+ * RefreshToken to paste into the plugin config.
+ *
+ * IMPORTANT: SmartThings does NOT allow localhost redirect URIs — the
+ * /authorize endpoint returns HTTP 403 for them. You must use a public HTTPS
+ * URL as the redirect. A convenient one is https://httpbin.org/get, which just
+ * echoes back the query string so you can read the `code`. You then paste that
+ * code here to exchange it for tokens.
  *
  * Prerequisites: an OAuth-In app created with the SmartThings CLI, e.g.
  *
  *   smartthings apps:create
  *     -> "OAuth-In App"
- *     -> Redirect URI:   http://localhost:8000/callback
+ *     -> Redirect URI:   https://httpbin.org/get
  *     -> Scopes:         r:devices:* x:devices:*
  *
- * which yields the OAuth Client ID and Client Secret used below.
+ * which yields the OAuth Client ID and Client Secret used below. To change the
+ * redirect URI / scopes of an existing app: smartthings apps:oauth:update <id>
  */
 
-import http from 'node:http';
 import readline from 'node:readline';
 import { URL } from 'node:url';
 
 const AUTHORIZE_URL = 'https://api.smartthings.com/oauth/authorize';
 const TOKEN_URL = 'https://api.smartthings.com/oauth/token';
 const SCOPES = ['r:devices:*', 'x:devices:*'];
-const DEFAULT_PORT = 8000;
-const CALLBACK_PATH = '/callback';
+const DEFAULT_REDIRECT_URI = 'https://httpbin.org/get';
 
 function ask(rl, question, fallback) {
   return new Promise((resolve) => {
@@ -37,39 +41,25 @@ function ask(rl, question, fallback) {
   });
 }
 
-async function waitForCode(port) {
-  return new Promise((resolve, reject) => {
-    const server = http.createServer((req, res) => {
-      const requestUrl = new URL(req.url, `http://localhost:${port}`);
-      if (requestUrl.pathname !== CALLBACK_PATH) {
-        res.writeHead(404);
-        res.end('Not found');
-        return;
-      }
-
-      const code = requestUrl.searchParams.get('code');
-      const error = requestUrl.searchParams.get('error');
-
-      res.writeHead(200, { 'Content-Type': 'text/html' });
-      res.end(
-        '<html><body style="font-family:sans-serif">'
-        + (code
-          ? '<h2>Authorization complete</h2><p>You can close this tab and return to the terminal.</p>'
-          : `<h2>Authorization failed</h2><p>${error || 'No code returned.'}</p>`)
-        + '</body></html>',
-      );
-
-      server.close();
+/** Accepts either a raw code or the full redirect URL and extracts the code. */
+function parseCode(input) {
+  const value = input.trim();
+  if (value.includes('code=')) {
+    try {
+      const url = new URL(value);
+      const code = url.searchParams.get('code');
       if (code) {
-        resolve(code);
-      } else {
-        reject(new Error(error || 'No authorization code returned'));
+        return code;
       }
-    });
-
-    server.on('error', reject);
-    server.listen(port);
-  });
+    } catch {
+      // not a URL, fall through
+    }
+    const match = value.match(/[?&]code=([^&\s]+)/);
+    if (match) {
+      return decodeURIComponent(match[1]);
+    }
+  }
+  return value;
 }
 
 async function exchangeCode({ clientId, clientSecret, code, redirectUri }) {
@@ -106,11 +96,17 @@ async function main() {
 
     const clientId = await ask(rl, 'OAuth Client ID');
     const clientSecret = await ask(rl, 'OAuth Client Secret');
-    const port = Number(await ask(rl, 'Local callback port', String(DEFAULT_PORT)));
-    const redirectUri = `http://localhost:${port}${CALLBACK_PATH}`;
+    const redirectUri = await ask(rl, 'Redirect URI (must match your app, public HTTPS)', DEFAULT_REDIRECT_URI);
 
     if (!clientId || !clientSecret) {
       throw new Error('Client ID and Client Secret are required.');
+    }
+
+    if (redirectUri.startsWith('http://') || redirectUri.includes('localhost')) {
+      throw new Error(
+        'SmartThings rejects localhost/http redirect URIs (403). Use a public HTTPS URL '
+        + '(e.g. https://httpbin.org/get) and register it on the app first.',
+      );
     }
 
     const authorizeUrl = new URL(AUTHORIZE_URL);
@@ -119,19 +115,25 @@ async function main() {
     authorizeUrl.searchParams.set('scope', SCOPES.join(' '));
     authorizeUrl.searchParams.set('redirect_uri', redirectUri);
 
-    console.log('\nMake sure this exact redirect URI is registered on your OAuth app:');
-    console.log(`  ${redirectUri}\n`);
-    console.log('Open this URL in your browser and approve access:\n');
-    console.log(`  ${authorizeUrl.toString()}\n`);
-    console.log(`Waiting for the SmartThings redirect on port ${port} ...`);
+    console.log('\n1) Open this URL in your browser and approve access:\n');
+    console.log(`   ${authorizeUrl.toString()}\n`);
+    console.log(`2) You will be redirected to ${redirectUri} — copy the "code" value`);
+    console.log('   from the page (or from the browser address bar, after "code=").');
+    console.log('   The code is single-use and expires within a few minutes.\n');
 
-    const code = await waitForCode(port);
+    const codeInput = await ask(rl, 'Paste the authorization code (or the full redirect URL)');
+    const code = parseCode(codeInput);
+    if (!code) {
+      throw new Error('No authorization code provided.');
+    }
+
     const tokens = await exchangeCode({ clientId, clientSecret, code, redirectUri });
 
-    console.log('\nSuccess! Add these to your plugin config (config.schema OAuth fields):\n');
+    console.log('\nSuccess! Add these to your plugin config (OAuth fields):\n');
     console.log(`  "ClientID": "${clientId}",`);
     console.log(`  "ClientSecret": "${clientSecret}",`);
     console.log(`  "RefreshToken": "${tokens.refresh_token}"\n`);
+    console.log('Remove the "AccessToken" (PAT) field and restart Homebridge.');
     console.log('The plugin renews the access token automatically from here on.');
   } catch (error) {
     console.error('\nSetup failed:', error.message);

--- a/config.schema.json
+++ b/config.schema.json
@@ -16,9 +16,25 @@
         "default": "https://api.smartthings.com/v1/"
       },
       "AccessToken": {
-        "title": "Access Token",
+        "title": "Personal Access Token (PAT)",
+        "description": "Legacy auth. PATs created after 2024-12-30 expire after 24h. Leave empty and fill the OAuth fields below to renew tokens automatically.",
         "type": "string",
         "default": ""
+      },
+      "ClientID": {
+        "title": "OAuth Client ID",
+        "description": "OAuth mode. Obtained via the SmartThings CLI (smartthings apps:create).",
+        "type": "string"
+      },
+      "ClientSecret": {
+        "title": "OAuth Client Secret",
+        "description": "OAuth mode. Obtained via the SmartThings CLI (smartthings apps:create).",
+        "type": "string"
+      },
+      "RefreshToken": {
+        "title": "OAuth Refresh Token",
+        "description": "OAuth mode. Obtained with the one-time setup helper (npx homebridge-samsung-windfree-ac-auth). It is rotated automatically and persisted to disk afterwards.",
+        "type": "string"
       },
       "OptionalWindFreeSwitch": {
         "title": "Expose a switch to enable/disable WindFree mode",
@@ -30,9 +46,8 @@
         "type": "boolean",
         "default": false
       }
-    }
-      ,
-      "required": ["name", "BaseURL", "AccessToken"]
+    },
+    "required": ["name", "BaseURL"]
   },
   "form": null,
   "display": null

--- a/config.schema.json
+++ b/config.schema.json
@@ -33,7 +33,7 @@
       },
       "RefreshToken": {
         "title": "OAuth Refresh Token",
-        "description": "OAuth mode. Obtained with the one-time setup helper (npx homebridge-samsung-windfree-ac-auth). It is rotated automatically and persisted to disk afterwards.",
+        "description": "OAuth mode. Obtained with the one-time setup helper (bin/oauth-setup.mjs). It is rotated automatically and persisted to disk afterwards.",
         "type": "string"
       },
       "OptionalWindFreeSwitch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "homebridge-samsung-windfree-ac",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-samsung-windfree-ac",
-      "version": "1.1.1",
+      "version": "1.1.3",
       "license": "Apache-2.0",
+      "bin": {
+        "homebridge-samsung-windfree-ac-auth": "bin/oauth-setup.mjs"
+      },
       "devDependencies": {
         "@stylistic/eslint-plugin": "^5.4.0",
         "@types/node": "^24.5.2",
@@ -22,7 +25,7 @@
       },
       "engines": {
         "homebridge": "^1.11.0 || ^2.0.0-beta.0",
-        "node": "^22"
+        "node": "^20 || ^22 || ^24"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint": "eslint src/**.ts --max-warnings=0",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run lint && npm run build"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
     "url": "https://github.com/igorxmath/homebridge-samsung-windfree-ac/issues"
   },
   "engines": {
-     "node": "^20 || ^22",
+    "node": "^20 || ^22 || ^24",
     "homebridge": "^1.11.0 || ^2.0.0-beta.0"
   },
   "main": "dist/index.js",
+  "bin": {
+    "homebridge-samsung-windfree-ac-auth": "bin/oauth-setup.mjs"
+  },
   "scripts": {
     "lint": "eslint src/**.ts --max-warnings=0",
     "watch": "npm run build && npm link && nodemon",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -2,12 +2,15 @@ import { API, DynamicPlatformPlugin, Logger, PlatformAccessory, PlatformConfig, 
 
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
 import { AirConditionerPlatformAccessory } from './platformAccessory';
+import { TokenManager } from './tokenManager';
 
 export class HomebridgePlatform implements DynamicPlatformPlugin {
   public readonly Service: typeof Service = this.api.hap.Service;
   public readonly Characteristic: typeof Characteristic = this.api.hap.Characteristic;
 
   public readonly accessories: PlatformAccessory[] = [];
+
+  public readonly tokenManager: TokenManager;
 
   constructor(
     public readonly log: Logger,
@@ -17,10 +20,20 @@ export class HomebridgePlatform implements DynamicPlatformPlugin {
   ) {
     this.log.debug('Finished initializing platform:', this.config.name);
 
+    this.tokenManager = new TokenManager(this.log, this.config, this.api.user.storagePath());
+
     this.api.on('didFinishLaunching', () => {
       log.debug('Executed didFinishLaunching callback');
       this.discoverDevices();
     });
+  }
+
+  /**
+   * Returns a valid SmartThings bearer token, transparently refreshing it in
+   * OAuth mode. Shared by discovery and every accessory.
+   */
+  getAccessToken(): Promise<string> {
+    return this.tokenManager.getAccessToken();
   }
 
   configureAccessory(accessory: PlatformAccessory) {
@@ -31,7 +44,6 @@ export class HomebridgePlatform implements DynamicPlatformPlugin {
 
   async discoverDevices() {
     const baseURL = this.config.BaseURL;
-    const accessToken = this.config.AccessToken;
 
     if (!baseURL || typeof baseURL !== 'string' || baseURL.trim() === '') {
       this.log.error('BaseURL is missing or empty in config. Plugin will not attempt device discovery.');
@@ -46,8 +58,19 @@ export class HomebridgePlatform implements DynamicPlatformPlugin {
       return;
     }
 
-    if (!accessToken || typeof accessToken !== 'string' || accessToken.trim() === '') {
-      this.log.error('AccessToken is missing or empty in config. Plugin will not attempt device discovery.');
+    if (this.tokenManager.mode === 'none') {
+      this.log.error(
+        'No SmartThings credentials configured. Provide either AccessToken (PAT) or '
+        + 'ClientID + ClientSecret + RefreshToken (OAuth). Plugin will not attempt device discovery.',
+      );
+      return;
+    }
+
+    let accessToken: string;
+    try {
+      accessToken = await this.getAccessToken();
+    } catch (error) {
+      this.log.error('Could not obtain a SmartThings access token:', (error as Error).message);
       return;
     }
 
@@ -65,6 +88,13 @@ export class HomebridgePlatform implements DynamicPlatformPlugin {
 
     if (!response.ok) {
       this.log.error('Failed to get devices from API. Status:', response.status, response.statusText);
+      if (response.status === 401) {
+        this.log.error(
+          'HTTP 401 Unauthorized: the SmartThings token is invalid or expired. '
+          + 'If using a PAT created after 2024-12-30, note it expires 24h after creation — '
+          + 'switch to OAuth to renew automatically.',
+        );
+      }
       return;
     }
 

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -30,10 +30,31 @@ enum AirConditionerDisplayState {
   Off = 'Light_On'
 }
 
+type DeviceStatus = Record<string, any>;
+
+// Serve cached status for this long before hitting the API again. A single read
+// cycle in HomeKit triggers many characteristic reads at once; the cache turns
+// them into one request instead of one per characteristic.
+const STATUS_TTL_MS = 4000;
+
+// Background poll interval. One request per device per tick, pushed to HomeKit.
+const POLL_INTERVAL_MS = 15000;
+
+// After sending a command, wait a moment for SmartThings to apply it, then
+// refresh and push the resulting state.
+const REFRESH_AFTER_SET_MS = 1500;
+
 export class AirConditionerPlatformAccessory {
   private service: Service;
+  private windFreeSwitchService?: Service;
+  private displaySwitchService?: Service;
 
   private temperatureUnit: TemperatureUnit = TemperatureUnit.Celsius;
+
+  private cachedStatus: DeviceStatus | null = null;
+  private statusFetchedAt = 0;
+  private inFlightStatus: Promise<DeviceStatus | null> | null = null;
+  private pollTimer?: NodeJS.Timeout;
 
   public static readonly supportedCapabilities =
     [
@@ -90,13 +111,13 @@ export class AirConditionerPlatformAccessory {
     if (this.platform.config.OptionalWindFreeSwitch) {
       this.platform.log.debug('Adding WindFree Switch');
 
-      const windFreeSwitchService =
+      this.windFreeSwitchService =
       this.accessory.getService('WindFree') ||
       this.accessory.addService(this.platform.Service.Switch, 'WindFree', `windfree-${accessory.context.device.deviceId}`);
 
-      windFreeSwitchService.setCharacteristic(this.platform.Characteristic.Name, 'WindFree');
+      this.windFreeSwitchService.setCharacteristic(this.platform.Characteristic.Name, 'WindFree');
 
-      windFreeSwitchService.getCharacteristic(this.platform.Characteristic.On)
+      this.windFreeSwitchService.getCharacteristic(this.platform.Characteristic.On)
         .onGet(this.handleWindFreeSwitchGet.bind(this))
         .onSet(this.handleWindFreeSwitchSet.bind(this));
     } else {
@@ -112,13 +133,13 @@ export class AirConditionerPlatformAccessory {
     if (this.platform.config.OptionalDisplaySwitch) {
       this.platform.log.debug('Adding Display Switch');
 
-      const displaySwitchService =
+      this.displaySwitchService =
       this.accessory.getService('Display') ||
       this.accessory.addService(this.platform.Service.Switch, 'Display', `display-${accessory.context.device.deviceId}`);
 
-      displaySwitchService.setCharacteristic(this.platform.Characteristic.Name, 'Display');
+      this.displaySwitchService.setCharacteristic(this.platform.Characteristic.Name, 'Display');
 
-      displaySwitchService.getCharacteristic(this.platform.Characteristic.On)
+      this.displaySwitchService.getCharacteristic(this.platform.Characteristic.On)
         .onGet(this.handleDisplaySwitchGet.bind(this))
         .onSet(this.handleDisplaySwitchSet.bind(this));
     } else {
@@ -129,91 +150,83 @@ export class AirConditionerPlatformAccessory {
         this.accessory.removeService(displaySwitchService);
       }
     }
+
+    // Warm the cache and start pushing state changes to HomeKit so values stay
+    // fresh without every characteristic read hitting the API. Skipped when no
+    // credentials are configured, to avoid spamming errors on cached accessories.
+    if (this.platform.tokenManager.mode !== 'none') {
+      this.refreshAndPush().catch(() => { /* logged in fetch */ });
+      this.pollTimer = setInterval(() => {
+        this.refreshAndPush().catch(() => { /* logged in fetch */ });
+      }, POLL_INTERVAL_MS);
+
+      this.platform.api.on('shutdown', () => {
+        if (this.pollTimer) {
+          clearInterval(this.pollTimer);
+        }
+      });
+    }
   }
 
   private async handleWindFreeSwitchGet(): Promise<CharacteristicValue> {
     this.platform.log.debug('Triggered GET WindFreeSwitch');
 
-    const deviceStatus = await this.getDeviceStatus();
-    const windFreeSwitchStatus = deviceStatus['custom.airConditionerOptionalMode'].acOptionalMode.value as AirConditionerOptionalMode;
-    const airConditionerMode = deviceStatus.airConditionerMode.airConditionerMode.value as AirConditionerMode;
-
-    if (airConditionerMode === AirConditionerMode.Auto) {
-      this.platform.log.debug('WindFreeSwitch is not supported in Auto mode');
-      return false;
-    }
-
-    return windFreeSwitchStatus === AirConditionerOptionalMode.WindFree;
+    const status = await this.requireStatus();
+    return this.expect(this.computeWindFree(status));
   }
 
   private async handleWindFreeSwitchSet(value: CharacteristicValue) {
     this.platform.log.debug('Triggered SET WindFreeSwitch:', value);
 
-    const deviceStatus = await this.getDeviceStatus();
-    const airConditionerMode = deviceStatus.airConditionerMode.airConditionerMode.value as AirConditionerMode;
+    const status = await this.getDeviceStatus();
+    const airConditionerMode = this.readAttr(status, 'airConditionerMode', 'airConditionerMode') as AirConditionerMode | undefined;
 
     if (airConditionerMode === AirConditionerMode.Auto) {
       this.platform.log.debug('WindFreeSwitch is not supported in Auto mode');
       return;
     }
 
-    const response = await fetch(this.commandURL, {
-      method: 'POST',
-      headers: {
-        'Authorization': 'Bearer ' + this.platform.config.AccessToken,
-        'Content-Type': 'application/json',
+    const ok = await this.sendCommands([
+      {
+        capability: 'custom.airConditionerOptionalMode',
+        command: 'setAcOptionalMode',
+        arguments: value ? [AirConditionerOptionalMode.WindFree] : [AirConditionerOptionalMode.Off],
       },
-      body: JSON.stringify({
-        commands: [
-          {
-            capability: 'custom.airConditionerOptionalMode',
-            command: 'setAcOptionalMode',
-            arguments: value ? [AirConditionerOptionalMode.WindFree] : [AirConditionerOptionalMode.Off],
-          },
-        ],
-      }),
-    });
+    ]);
 
-    if (!response.ok) {
+    if (!ok) {
       this.platform.log.error('Failed to set WindFreeSwitch');
+    } else {
+      this.scheduleRefresh();
     }
   }
 
   private async handleDisplaySwitchGet(): Promise<CharacteristicValue> {
     this.platform.log.debug('Triggered GET DisplaySwitch');
 
-    const deviceStatus = await this.getDeviceStatus();
-    const displaySwitchStatus = deviceStatus['samsungce.airConditionerLighting'].lighting.value;
-
-    return displaySwitchStatus === SwitchState.On;
+    const status = await this.requireStatus();
+    return this.expect(this.computeDisplay(status));
   }
 
   private async handleDisplaySwitchSet(value: CharacteristicValue) {
     this.platform.log.debug('Triggered SET DisplaySwitch:', value);
 
-    const response = await fetch(this.commandURL, {
-      method: 'POST',
-      headers: {
-        'Authorization': 'Bearer ' + this.platform.config.AccessToken,
-        'Content-Type': 'application/json',
+    const ok = await this.sendCommands([
+      {
+        capability: 'execute',
+        command: 'execute',
+        arguments: ['mode/vs/0', {
+          'x.com.samsung.da.options': [
+            value ? AirConditionerDisplayState.On : AirConditionerDisplayState.Off,
+          ],
+        }],
       },
-      body: JSON.stringify({
-        commands: [
-          {
-            capability: 'execute',
-            command: 'execute',
-            arguments: ['mode/vs/0', {
-              'x.com.samsung.da.options': [
-                value ? AirConditionerDisplayState.On : AirConditionerDisplayState.Off,
-              ],
-            }],
-          },
-        ],
-      }),
-    });
+    ]);
 
-    if (!response.ok) {
+    if (!ok) {
       this.platform.log.error('Failed to set DisplaySwitch');
+    } else {
+      this.scheduleRefresh();
     }
   }
 
@@ -228,57 +241,21 @@ export class AirConditionerPlatformAccessory {
   private async handleCurrentHeatingCoolingStateGet(): Promise<CharacteristicValue> {
     this.platform.log.debug('Triggered GET CurrentHeatingCoolingState');
 
-    const deviceStatus = await this.getDeviceStatus();
-    const currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState;
-    const airConditionerSwitchStatus = deviceStatus.switch.switch.value as SwitchState;
-    const airConditionerMode = deviceStatus.airConditionerMode.airConditionerMode.value as AirConditionerMode;
-    const coolingSetpoint = deviceStatus.thermostatCoolingSetpoint.coolingSetpoint.value;
-    const temperature = deviceStatus.temperatureMeasurement.temperature.value;
-
-    this.platform.log.debug('CurrentHeatingCoolingState:', airConditionerMode);
-
-    if (airConditionerSwitchStatus === SwitchState.Off) {
-      return currentHeatingCoolingState.OFF;
-    } else if (airConditionerMode === AirConditionerMode.Cool) {
-      return currentHeatingCoolingState.COOL;
-    } else if (airConditionerMode === AirConditionerMode.Auto) {
-      return temperature > coolingSetpoint ? currentHeatingCoolingState.COOL : currentHeatingCoolingState.HEAT;
-    } else if (airConditionerMode === AirConditionerMode.Heat) {
-      return currentHeatingCoolingState.HEAT;
-    } else {
-      return currentHeatingCoolingState.OFF;
-    }
+    const status = await this.requireStatus();
+    return this.expect(this.computeCurrentHeatingCoolingState(status));
   }
 
   private async handleTargetHeatingCoolingStateGet(): Promise<CharacteristicValue> {
     this.platform.log.debug('Triggered GET TargetHeatingCoolingState');
 
-    const deviceStatus = await this.getDeviceStatus();
-    const airConditionerSwitchStatus = deviceStatus.switch.switch.value as SwitchState;
-    const targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState;
-    const airConditionerMode = deviceStatus.airConditionerMode.airConditionerMode.value as AirConditionerMode;
-
-    this.platform.log.debug('TargetHeatingCoolingState:', airConditionerMode);
-
-    if (airConditionerSwitchStatus === SwitchState.Off) {
-      return targetHeatingCoolingState.OFF;
-    } else if (airConditionerMode === AirConditionerMode.Cool) {
-      return targetHeatingCoolingState.COOL;
-    } else if (airConditionerMode === AirConditionerMode.Auto) {
-      return targetHeatingCoolingState.AUTO;
-    } else if (airConditionerMode === AirConditionerMode.Heat) {
-      return targetHeatingCoolingState.HEAT;
-    } else {
-      return targetHeatingCoolingState.OFF;
-    }
+    const status = await this.requireStatus();
+    return this.expect(this.computeTargetHeatingCoolingState(status));
   }
 
   private async handleTargetHeatingCoolingStateSet(value: CharacteristicValue) {
     this.platform.log.debug('Triggered SET TargetHeatingCoolingState:', value);
 
     const TargetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState;
-
-    this.platform.log.debug('TargetHeatingCoolingState:', TargetHeatingCoolingState);
 
     const targetHeatingCoolingStateToAirConditionerMode = () => {
       switch (value) {
@@ -312,79 +289,364 @@ export class AirConditionerPlatformAccessory {
       },
     ];
 
-    const response = await fetch(this.commandURL, {
-      method: 'POST',
-      headers: {
-        'Authorization': 'Bearer ' + this.platform.config.AccessToken,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ commands }),
-    });
+    const ok = await this.sendCommands(commands);
 
-    if (!response.ok) {
+    if (!ok) {
       this.platform.log.error('Failed to set TargetHeatingCoolingState');
+    } else {
+      this.scheduleRefresh();
     }
   }
 
   private async handleCurrentTemperatureGet(): Promise<CharacteristicValue> {
     this.platform.log.debug('Triggered GET CurrentTemperature');
 
-    const deviceStatus = await this.getDeviceStatus();
-    const temperature = deviceStatus.temperatureMeasurement.temperature.value;
-
-    return temperature;
+    const status = await this.requireStatus();
+    return this.expect(this.computeCurrentTemperature(status));
   }
 
   private async handleTargetTemperatureGet(): Promise<CharacteristicValue> {
     this.platform.log.debug('Triggered GET TargetTemperature');
 
-    const deviceStatus = await this.getDeviceStatus();
-    const temperature = deviceStatus.thermostatCoolingSetpoint.coolingSetpoint.value;
-
-    return temperature;
+    const status = await this.requireStatus();
+    return this.expect(this.computeTargetTemperature(status));
   }
 
   private async handleTargetTemperatureSet(value: CharacteristicValue) {
     this.platform.log.debug('Triggered SET TargetTemperature:', value);
 
-    const response = await fetch(this.commandURL, {
-      method: 'POST',
-      headers: {
-        'Authorization': 'Bearer ' + this.platform.config.AccessToken,
-        'Content-Type': 'application/json',
+    const ok = await this.sendCommands([
+      {
+        capability: 'thermostatCoolingSetpoint',
+        command: 'setCoolingSetpoint',
+        arguments: [value],
       },
-      body: JSON.stringify({
-        commands: [
-          {
-            capability: 'thermostatCoolingSetpoint',
-            command: 'setCoolingSetpoint',
-            arguments: [value],
-          },
-        ],
-      }),
-    });
+    ]);
 
-    if (!response.ok) {
+    if (!ok) {
       this.platform.log.error('Failed to set TargetTemperature');
+    } else {
+      this.scheduleRefresh();
     }
   }
 
-  private async getDeviceStatus() {
-    this.platform.log.debug('Triggered GET DeviceStatus');
+  // ---------------------------------------------------------------------------
+  // Status computation (pure: derive a characteristic value from a status object)
+  // Each returns `undefined` when the required data is missing, so callers can
+  // decide whether to throw (on-demand read) or skip (background push).
+  // ---------------------------------------------------------------------------
 
-    const response = await fetch(this.statusURL, {
-      headers: {
-        'Authorization': 'Bearer ' + this.platform.config.AccessToken,
-      },
-    });
+  private computeCurrentHeatingCoolingState(status: DeviceStatus): CharacteristicValue | undefined {
+    const currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState;
+    const airConditionerSwitchStatus = this.readAttr(status, 'switch', 'switch') as SwitchState | undefined;
+    const airConditionerMode = this.readAttr(status, 'airConditionerMode', 'airConditionerMode') as AirConditionerMode | undefined;
 
-    if (!response.ok) {
-      this.platform.log.error('Failed to get device status');
-      return;
+    if (airConditionerSwitchStatus === undefined || airConditionerMode === undefined) {
+      return undefined;
     }
 
-    const data: any = await response.json();
+    if (airConditionerSwitchStatus === SwitchState.Off) {
+      return currentHeatingCoolingState.OFF;
+    } else if (airConditionerMode === AirConditionerMode.Cool) {
+      return currentHeatingCoolingState.COOL;
+    } else if (airConditionerMode === AirConditionerMode.Auto) {
+      const coolingSetpoint = this.readAttr(status, 'thermostatCoolingSetpoint', 'coolingSetpoint');
+      const temperature = this.readAttr(status, 'temperatureMeasurement', 'temperature');
+      if (typeof coolingSetpoint !== 'number' || typeof temperature !== 'number') {
+        return currentHeatingCoolingState.COOL;
+      }
+      return temperature > coolingSetpoint ? currentHeatingCoolingState.COOL : currentHeatingCoolingState.HEAT;
+    } else if (airConditionerMode === AirConditionerMode.Heat) {
+      return currentHeatingCoolingState.HEAT;
+    } else {
+      return currentHeatingCoolingState.OFF;
+    }
+  }
 
-    return data.components.main;
+  private computeTargetHeatingCoolingState(status: DeviceStatus): CharacteristicValue | undefined {
+    const targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState;
+    const airConditionerSwitchStatus = this.readAttr(status, 'switch', 'switch') as SwitchState | undefined;
+    const airConditionerMode = this.readAttr(status, 'airConditionerMode', 'airConditionerMode') as AirConditionerMode | undefined;
+
+    if (airConditionerSwitchStatus === undefined || airConditionerMode === undefined) {
+      return undefined;
+    }
+
+    if (airConditionerSwitchStatus === SwitchState.Off) {
+      return targetHeatingCoolingState.OFF;
+    } else if (airConditionerMode === AirConditionerMode.Cool) {
+      return targetHeatingCoolingState.COOL;
+    } else if (airConditionerMode === AirConditionerMode.Auto) {
+      return targetHeatingCoolingState.AUTO;
+    } else if (airConditionerMode === AirConditionerMode.Heat) {
+      return targetHeatingCoolingState.HEAT;
+    } else {
+      return targetHeatingCoolingState.OFF;
+    }
+  }
+
+  private computeCurrentTemperature(status: DeviceStatus): CharacteristicValue | undefined {
+    const temperature = this.readAttr(status, 'temperatureMeasurement', 'temperature');
+    return typeof temperature === 'number' ? temperature : undefined;
+  }
+
+  private computeTargetTemperature(status: DeviceStatus): CharacteristicValue | undefined {
+    const temperature = this.readAttr(status, 'thermostatCoolingSetpoint', 'coolingSetpoint');
+    return typeof temperature === 'number' ? temperature : undefined;
+  }
+
+  private computeWindFree(status: DeviceStatus): CharacteristicValue | undefined {
+    const airConditionerMode = this.readAttr(status, 'airConditionerMode', 'airConditionerMode') as AirConditionerMode | undefined;
+
+    if (airConditionerMode === AirConditionerMode.Auto) {
+      this.platform.log.debug('WindFreeSwitch is not supported in Auto mode');
+      return false;
+    }
+
+    const windFreeSwitchStatus =
+      this.readAttr(status, 'custom.airConditionerOptionalMode', 'acOptionalMode') as AirConditionerOptionalMode | undefined;
+
+    if (windFreeSwitchStatus === undefined) {
+      return undefined;
+    }
+
+    return windFreeSwitchStatus === AirConditionerOptionalMode.WindFree;
+  }
+
+  private computeDisplay(status: DeviceStatus): CharacteristicValue | undefined {
+    const displaySwitchStatus = this.readAttr(status, 'samsungce.airConditionerLighting', 'lighting') as SwitchState | undefined;
+
+    if (displaySwitchStatus === undefined) {
+      return undefined;
+    }
+
+    return displaySwitchStatus === SwitchState.On;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Status fetching, caching and pushing
+  // ---------------------------------------------------------------------------
+
+  /** Reads `status[capability][attribute].value`, tolerating missing pieces. */
+  private readAttr(status: DeviceStatus | null, capability: string, attribute: string): unknown {
+    return status?.[capability]?.[attribute]?.value;
+  }
+
+  /** Throws a clean HAP communication error when data is unavailable. */
+  private expect(value: CharacteristicValue | undefined): CharacteristicValue {
+    if (value === undefined) {
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
+    return value;
+  }
+
+  private async requireStatus(): Promise<DeviceStatus> {
+    const status = await this.getDeviceStatus();
+    if (!status) {
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
+    return status;
+  }
+
+  private async refreshAndPush(forceRefresh = false): Promise<void> {
+    const status = await this.getDeviceStatus(forceRefresh);
+    if (status) {
+      this.pushStatus(status);
+    }
+  }
+
+  private pushStatus(status: DeviceStatus): void {
+    const chr = this.platform.Characteristic;
+
+    const currentState = this.computeCurrentHeatingCoolingState(status);
+    if (currentState !== undefined) {
+      this.service.updateCharacteristic(chr.CurrentHeatingCoolingState, currentState);
+    }
+
+    const targetState = this.computeTargetHeatingCoolingState(status);
+    if (targetState !== undefined) {
+      this.service.updateCharacteristic(chr.TargetHeatingCoolingState, targetState);
+    }
+
+    const currentTemp = this.computeCurrentTemperature(status);
+    if (currentTemp !== undefined) {
+      this.service.updateCharacteristic(chr.CurrentTemperature, currentTemp);
+    }
+
+    const targetTemp = this.computeTargetTemperature(status);
+    if (targetTemp !== undefined) {
+      this.service.updateCharacteristic(chr.TargetTemperature, targetTemp);
+    }
+
+    if (this.windFreeSwitchService) {
+      const windFree = this.computeWindFree(status);
+      if (windFree !== undefined) {
+        this.windFreeSwitchService.updateCharacteristic(chr.On, windFree);
+      }
+    }
+
+    if (this.displaySwitchService) {
+      const display = this.computeDisplay(status);
+      if (display !== undefined) {
+        this.displaySwitchService.updateCharacteristic(chr.On, display);
+      }
+    }
+  }
+
+  /** Invalidate the cache and schedule a fresh read once the command applied. */
+  private scheduleRefresh(): void {
+    this.statusFetchedAt = 0;
+    setTimeout(() => {
+      this.refreshAndPush(true).catch(() => { /* logged in fetch */ });
+    }, REFRESH_AFTER_SET_MS);
+  }
+
+  /**
+   * Returns the device status, served from a short-lived cache and coalescing
+   * concurrent callers into a single HTTP request. Never returns `undefined`;
+   * on failure it returns the last-known status (or `null`).
+   */
+  private async getDeviceStatus(forceRefresh = false): Promise<DeviceStatus | null> {
+    if (!forceRefresh && this.cachedStatus && Date.now() - this.statusFetchedAt < STATUS_TTL_MS) {
+      return this.cachedStatus;
+    }
+
+    if (this.inFlightStatus) {
+      return this.inFlightStatus;
+    }
+
+    this.inFlightStatus = this.fetchDeviceStatus().finally(() => {
+      this.inFlightStatus = null;
+    });
+
+    return this.inFlightStatus;
+  }
+
+  private async fetchDeviceStatus(): Promise<DeviceStatus | null> {
+    this.platform.log.debug('Triggered GET DeviceStatus');
+
+    let token: string;
+    try {
+      token = await this.platform.getAccessToken();
+    } catch (error) {
+      this.platform.log.error('Cannot get access token for device status:', (error as Error).message);
+      return this.cachedStatus;
+    }
+
+    let response = await this.doStatusFetch(token);
+
+    // A 401 usually means the token rotated/expired; refresh once and retry.
+    if (response && response.status === 401) {
+      this.platform.log.warn('Device status returned 401; refreshing token and retrying.');
+      try {
+        token = await this.platform.tokenManager.forceRefresh();
+        response = await this.doStatusFetch(token);
+      } catch (error) {
+        this.platform.log.error('Token refresh after 401 failed:', (error as Error).message);
+      }
+    }
+
+    if (!response) {
+      return this.cachedStatus;
+    }
+
+    if (response.status === 429) {
+      this.platform.log.warn(
+        'SmartThings rate limit hit (HTTP 429) while reading device status; using cached values and backing off.',
+      );
+      return this.cachedStatus;
+    }
+
+    if (!response.ok) {
+      this.platform.log.error(`Failed to get device status (HTTP ${response.status} ${response.statusText})`);
+      if (response.status === 401) {
+        this.platform.log.error(
+          'HTTP 401 Unauthorized: the SmartThings token is invalid or expired. '
+          + 'A PAT created after 2024-12-30 expires 24h after creation — switch to OAuth to renew automatically.',
+        );
+      }
+      return this.cachedStatus;
+    }
+
+    let data: any;
+    try {
+      data = await response.json();
+    } catch {
+      this.platform.log.error('Failed to parse device status response as JSON');
+      return this.cachedStatus;
+    }
+
+    const main = data?.components?.main;
+    if (!main) {
+      this.platform.log.error('Device status response is missing components.main');
+      return this.cachedStatus;
+    }
+
+    this.cachedStatus = main;
+    this.statusFetchedAt = Date.now();
+    return main;
+  }
+
+  private async doStatusFetch(token: string): Promise<Response | null> {
+    try {
+      return await fetch(this.statusURL, {
+        headers: {
+          'Authorization': 'Bearer ' + token,
+        },
+      });
+    } catch (error) {
+      this.platform.log.error('Network error while reading device status:', (error as Error).message);
+      return null;
+    }
+  }
+
+  /** Sends commands, refreshing the token once on a 401. Returns success. */
+  private async sendCommands(commands: unknown[]): Promise<boolean> {
+    let token: string;
+    try {
+      token = await this.platform.getAccessToken();
+    } catch (error) {
+      this.platform.log.error('Cannot get access token to send command:', (error as Error).message);
+      return false;
+    }
+
+    let response = await this.doCommand(token, commands);
+
+    if (response && response.status === 401) {
+      this.platform.log.warn('Command returned 401; refreshing token and retrying.');
+      try {
+        token = await this.platform.tokenManager.forceRefresh();
+        response = await this.doCommand(token, commands);
+      } catch (error) {
+        this.platform.log.error('Token refresh after 401 failed:', (error as Error).message);
+      }
+    }
+
+    if (!response) {
+      return false;
+    }
+
+    if (!response.ok) {
+      this.platform.log.error(`Command failed (HTTP ${response.status} ${response.statusText})`);
+      return false;
+    }
+
+    return true;
+  }
+
+  private async doCommand(token: string, commands: unknown[]): Promise<Response | null> {
+    try {
+      return await fetch(this.commandURL, {
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + token,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ commands }),
+      });
+    } catch (error) {
+      this.platform.log.error('Network error while sending command:', (error as Error).message);
+      return null;
+    }
   }
 }

--- a/src/tokenManager.ts
+++ b/src/tokenManager.ts
@@ -1,0 +1,232 @@
+import { Logger, PlatformConfig } from 'homebridge';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const TOKEN_URL = 'https://api.smartthings.com/oauth/token';
+
+// Renew the access token this many milliseconds before it actually expires,
+// so an in-flight request never races the expiry.
+const EXPIRY_MARGIN_MS = 5 * 60 * 1000;
+
+// Fallback lifetime used only when the token endpoint omits `expires_in`.
+const DEFAULT_EXPIRES_IN_S = 24 * 60 * 60;
+
+interface PersistedTokens {
+  refreshToken?: string;
+  accessToken?: string;
+  expiresAt?: number;
+}
+
+/**
+ * Handles SmartThings authentication in one of two mutually exclusive modes:
+ *
+ *  - PAT: a static Personal Access Token supplied in the config. Returned as-is.
+ *    Note that PATs created after 2024-12-30 expire 24h after creation and cannot
+ *    be renewed programmatically.
+ *
+ *  - OAuth: ClientID + ClientSecret + RefreshToken. The access token is fetched
+ *    from the refresh token and renewed automatically before it expires. Refresh
+ *    tokens rotate on every use, so the newest one is persisted to disk and takes
+ *    priority over the (now stale) value in the config on subsequent runs.
+ */
+export class TokenManager {
+  public readonly mode: 'pat' | 'oauth' | 'none';
+
+  private readonly pat?: string;
+  private readonly clientId?: string;
+  private readonly clientSecret?: string;
+  private readonly persistPath: string;
+
+  private refreshToken?: string;
+  private accessToken?: string;
+  private expiresAt = 0;
+
+  private loaded = false;
+  private refreshPromise: Promise<string> | null = null;
+
+  constructor(
+    private readonly log: Logger,
+    config: PlatformConfig,
+    storagePath: string,
+  ) {
+    this.pat = typeof config.AccessToken === 'string' && config.AccessToken.trim() !== ''
+      ? config.AccessToken.trim()
+      : undefined;
+    this.clientId = typeof config.ClientID === 'string' && config.ClientID.trim() !== ''
+      ? config.ClientID.trim()
+      : undefined;
+    this.clientSecret = typeof config.ClientSecret === 'string' && config.ClientSecret.trim() !== ''
+      ? config.ClientSecret.trim()
+      : undefined;
+    this.refreshToken = typeof config.RefreshToken === 'string' && config.RefreshToken.trim() !== ''
+      ? config.RefreshToken.trim()
+      : undefined;
+
+    this.persistPath = path.join(storagePath, '.samsung-windfree-oauth.json');
+
+    if (this.clientId && this.clientSecret && this.refreshToken) {
+      this.mode = 'oauth';
+    } else if (this.pat) {
+      this.mode = 'pat';
+    } else {
+      this.mode = 'none';
+    }
+  }
+
+  /**
+   * Returns a valid bearer token, refreshing it automatically in OAuth mode.
+   * Throws in 'none' mode or when a refresh fails.
+   */
+  async getAccessToken(): Promise<string> {
+    if (this.mode === 'pat') {
+      return this.pat!;
+    }
+
+    if (this.mode === 'none') {
+      throw new Error(
+        'No SmartThings credentials configured. Provide either AccessToken (PAT) or ClientID + ClientSecret + RefreshToken (OAuth).',
+      );
+    }
+
+    await this.loadPersisted();
+
+    if (this.accessToken && Date.now() < this.expiresAt - EXPIRY_MARGIN_MS) {
+      return this.accessToken;
+    }
+
+    return this.refresh();
+  }
+
+  /**
+   * Forces a refresh regardless of the cached expiry. Call this after a 401 to
+   * recover from a token that was revoked/rotated out-of-band.
+   */
+  async forceRefresh(): Promise<string> {
+    if (this.mode !== 'oauth') {
+      return this.getAccessToken();
+    }
+    await this.loadPersisted();
+    this.expiresAt = 0;
+    return this.refresh();
+  }
+
+  private async refresh(): Promise<string> {
+    // Coalesce concurrent refreshes into a single request.
+    if (this.refreshPromise) {
+      return this.refreshPromise;
+    }
+
+    this.refreshPromise = this.doRefresh().finally(() => {
+      this.refreshPromise = null;
+    });
+
+    return this.refreshPromise;
+  }
+
+  private async doRefresh(): Promise<string> {
+    if (!this.refreshToken) {
+      throw new Error('OAuth refresh token is missing. Re-run the OAuth setup helper.');
+    }
+
+    const basic = Buffer.from(`${this.clientId}:${this.clientSecret}`).toString('base64');
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: this.clientId!,
+      refresh_token: this.refreshToken,
+    });
+
+    let response: Response;
+    try {
+      response = await fetch(TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Basic ${basic}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Accept': 'application/json',
+        },
+        body: body.toString(),
+      });
+    } catch (error) {
+      throw new Error(`Network error while refreshing SmartThings token: ${(error as Error).message}`);
+    }
+
+    const text = await response.text();
+
+    if (!response.ok) {
+      if (text.includes('invalid_grant')) {
+        this.log.error(
+          'SmartThings refused the refresh token (invalid_grant). It was revoked or expired — '
+          + 're-run the OAuth setup helper to obtain a new RefreshToken.',
+        );
+      } else {
+        this.log.error(`Failed to refresh SmartThings token (HTTP ${response.status} ${response.statusText}): ${text}`);
+      }
+      throw new Error(`Token refresh failed with HTTP ${response.status}`);
+    }
+
+    let data: { access_token?: string; refresh_token?: string; expires_in?: number };
+    try {
+      data = JSON.parse(text);
+    } catch {
+      throw new Error('Token refresh returned a non-JSON response');
+    }
+
+    if (!data.access_token) {
+      throw new Error('Token refresh response did not contain an access_token');
+    }
+
+    this.accessToken = data.access_token;
+    this.expiresAt = Date.now() + (data.expires_in ?? DEFAULT_EXPIRES_IN_S) * 1000;
+
+    // Refresh tokens rotate: persist the new one so it survives restarts.
+    if (data.refresh_token && data.refresh_token !== this.refreshToken) {
+      this.refreshToken = data.refresh_token;
+    }
+
+    await this.persist();
+
+    this.log.debug('SmartThings access token refreshed; valid until', new Date(this.expiresAt).toISOString());
+
+    return this.accessToken;
+  }
+
+  private async loadPersisted(): Promise<void> {
+    if (this.loaded) {
+      return;
+    }
+    this.loaded = true;
+
+    try {
+      const raw = await fs.readFile(this.persistPath, 'utf8');
+      const persisted = JSON.parse(raw) as PersistedTokens;
+
+      // A persisted (rotated) refresh token always beats the stale config value.
+      if (persisted.refreshToken) {
+        this.refreshToken = persisted.refreshToken;
+      }
+      if (persisted.accessToken && persisted.expiresAt) {
+        this.accessToken = persisted.accessToken;
+        this.expiresAt = persisted.expiresAt;
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') {
+        this.log.warn('Could not read persisted OAuth tokens:', (error as Error).message);
+      }
+    }
+  }
+
+  private async persist(): Promise<void> {
+    const data: PersistedTokens = {
+      refreshToken: this.refreshToken,
+      accessToken: this.accessToken,
+      expiresAt: this.expiresAt,
+    };
+
+    try {
+      await fs.writeFile(this.persistPath, JSON.stringify(data), { encoding: 'utf8', mode: 0o600 });
+    } catch (error) {
+      this.log.warn('Could not persist OAuth tokens to disk:', (error as Error).message);
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

Two issues make the plugin unreliable in current SmartThings/Homebridge setups:

1. **Status-read crashes.** The plugin made one `/status` request per HomeKit
   characteristic, so a single read cycle fired 7–9 parallel requests per
   device and hit the SmartThings rate limit (HTTP 429). On failure the status
   getter returned `undefined` and every handler dereferenced it, producing
   repeated `Failed to get device status` / `Cannot read properties of
   undefined` errors (see #7, #13, #20).

2. **24h token expiry.** Personal Access Tokens created after 2024-12-30 expire
   24 hours after creation and cannot be extended, so a PAT-based setup breaks
   every day.

## Changes

### Stability
- Cache device status with a short TTL and coalesce concurrent reads into a
  single request; a background poll pushes state to HomeKit via
  `updateCharacteristic` (also fixes the WindFree switch not updating).
- Null-safe capability access; handlers throw a clean HAP communication error
  instead of crashing when data is unavailable.
- Distinguish and log HTTP 401 (token) vs 429 (rate limit); retry once on 401
  after refreshing the token; back off on 429.

### OAuth2 authentication
- New `TokenManager` supporting either a PAT (unchanged, backward compatible)
  or OAuth (`ClientID` / `ClientSecret` / `RefreshToken`) with automatic
  access-token renewal. Rotated refresh tokens are persisted to the Homebridge
  storage directory, so no manual daily regeneration is needed.
- `bin/oauth-setup.mjs`: dependency-free one-time helper to obtain the refresh
  token (public-HTTPS redirect flow, since SmartThings rejects localhost
  redirects with a 403).

### Misc
- Widen `engines.node` to `^20 || ^22 || ^24` (fixes the Node 24 warning, #26).
- Add a `prepare` script so installs from source build automatically.
- Document both authentication options and the OAuth app setup in the README.

## Backward compatibility

Existing PAT configurations keep working unchanged; OAuth is opt-in via the new
config fields.