### PR TITLE
feat: expose indoor relative humidity as an optional sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Configuration parameters:
 - `ClientID` / `ClientSecret` / `RefreshToken`: OAuth auth (Option B).
 - `OptionalWindFreeSwitch`: expose a switch for WindFree mode.
 - `OptionalDisplaySwitch`: expose a switch for the display light.
+- `OptionalHumiditySensor`: expose the indoor relative humidity (only for units that report it).
 
 Sample configuration (PAT):
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -45,6 +45,12 @@
         "title": "Expose a switch to turn on/off the display light",
         "type": "boolean",
         "default": false
+      },
+      "OptionalHumiditySensor": {
+        "title": "Expose the indoor relative humidity reported by the unit",
+        "description": "Only enable this for units that report humidity (relativeHumidityMeasurement).",
+        "type": "boolean",
+        "default": false
       }
     },
     "required": ["name", "BaseURL"]

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -48,6 +48,7 @@ export class AirConditionerPlatformAccessory {
   private service: Service;
   private windFreeSwitchService?: Service;
   private displaySwitchService?: Service;
+  private humiditySensorEnabled = false;
 
   private temperatureUnit: TemperatureUnit = TemperatureUnit.Celsius;
 
@@ -149,6 +150,22 @@ export class AirConditionerPlatformAccessory {
 
         this.accessory.removeService(displaySwitchService);
       }
+    }
+
+    this.platform.log.debug('Optional Humidity Sensor: ', this.platform.config.OptionalHumiditySensor);
+    if (this.platform.config.OptionalHumiditySensor) {
+      this.platform.log.debug('Adding Humidity Sensor');
+
+      this.humiditySensorEnabled = true;
+
+      this.service.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
+        .onGet(this.handleCurrentRelativeHumidityGet.bind(this));
+    } else if (this.service.testCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)) {
+      this.platform.log.debug('Removing Humidity Sensor');
+
+      this.service.removeCharacteristic(
+        this.service.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity),
+      );
     }
 
     // Warm the cache and start pushing state changes to HomeKit so values stay
@@ -312,6 +329,13 @@ export class AirConditionerPlatformAccessory {
     return this.expect(this.computeTargetTemperature(status));
   }
 
+  private async handleCurrentRelativeHumidityGet(): Promise<CharacteristicValue> {
+    this.platform.log.debug('Triggered GET CurrentRelativeHumidity');
+
+    const status = await this.requireStatus();
+    return this.expect(this.computeCurrentRelativeHumidity(status));
+  }
+
   private async handleTargetTemperatureSet(value: CharacteristicValue) {
     this.platform.log.debug('Triggered SET TargetTemperature:', value);
 
@@ -395,6 +419,11 @@ export class AirConditionerPlatformAccessory {
     return typeof temperature === 'number' ? temperature : undefined;
   }
 
+  private computeCurrentRelativeHumidity(status: DeviceStatus): CharacteristicValue | undefined {
+    const humidity = this.readAttr(status, 'relativeHumidityMeasurement', 'humidity');
+    return typeof humidity === 'number' ? humidity : undefined;
+  }
+
   private computeWindFree(status: DeviceStatus): CharacteristicValue | undefined {
     const airConditionerMode = this.readAttr(status, 'airConditionerMode', 'airConditionerMode') as AirConditionerMode | undefined;
 
@@ -476,6 +505,13 @@ export class AirConditionerPlatformAccessory {
     const targetTemp = this.computeTargetTemperature(status);
     if (targetTemp !== undefined) {
       this.service.updateCharacteristic(chr.TargetTemperature, targetTemp);
+    }
+
+    if (this.humiditySensorEnabled) {
+      const humidity = this.computeCurrentRelativeHumidity(status);
+      if (humidity !== undefined) {
+        this.service.updateCharacteristic(chr.CurrentRelativeHumidity, humidity);
+      }
     }
 
     if (this.windFreeSwitchService) {


### PR DESCRIPTION
## What

Expose the indoor relative humidity reported by the unit as an optional `CurrentRelativeHumidity` characteristic on the Thermostat service.

## Why

Many Samsung WindFree units report `relativeHumidityMeasurement`. Surfacing it lets the Home app show room humidity and use it in automations, without adding a separate accessory.

## How

- New `OptionalHumiditySensor` config flag (opt-in, default `false`), consistent with the existing `Optional*` switches.
- Reads `relativeHumidityMeasurement.humidity` through the existing `readAttr` / `compute*` / `expect` pattern, and is kept fresh by the existing background poll/push path.
- When the flag is disabled the characteristic is removed, so units that do not report humidity are unaffected.

## Testing

- `tsc --noEmit` and `eslint --max-warnings=0` pass clean.
- The read path mirrors the existing `CurrentTemperature` handling and has been running against a live WindFree unit; humidity reads correctly and updates on the background poll.
