### PR TITLE
feat: expose optional vertical/horizontal swing direction switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Configuration parameters:
 - `ClientID` / `ClientSecret` / `RefreshToken`: OAuth auth (Option B).
 - `OptionalWindFreeSwitch`: expose a switch for WindFree mode.
 - `OptionalDisplaySwitch`: expose a switch for the display light.
+- `OptionalSwingDirectionSwitches`: expose switches for vertical/horizontal swing direction.
 
 Sample configuration (PAT):
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -45,6 +45,11 @@
         "title": "Expose a switch to turn on/off the display light",
         "type": "boolean",
         "default": false
+      },
+      "OptionalSwingDirectionSwitches": {
+        "title": "Expose switches to set vertical/horizontal swing direction",
+        "type": "boolean",
+        "default": false
       }
     },
     "required": ["name", "BaseURL"]

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -30,6 +30,12 @@ enum AirConditionerDisplayState {
   Off = 'Light_On'
 }
 
+enum OscillationMode {
+  Fixed = 'fixed',
+  Vertical = 'vertical',
+  Horizontal = 'horizontal'
+}
+
 type DeviceStatus = Record<string, any>;
 
 // Serve cached status for this long before hitting the API again. A single read
@@ -48,6 +54,8 @@ export class AirConditionerPlatformAccessory {
   private service: Service;
   private windFreeSwitchService?: Service;
   private displaySwitchService?: Service;
+  private swingVerticalService?: Service;
+  private swingHorizontalService?: Service;
 
   private temperatureUnit: TemperatureUnit = TemperatureUnit.Celsius;
 
@@ -151,6 +159,25 @@ export class AirConditionerPlatformAccessory {
       }
     }
 
+    this.platform.log.debug('Optional Swing Direction Switches: ', this.platform.config.OptionalSwingDirectionSwitches);
+    if (this.platform.config.OptionalSwingDirectionSwitches) {
+      this.platform.log.debug('Adding Swing Direction Switches');
+
+      this.swingVerticalService = this.setupSwingDirectionSwitch(
+        'Swing Vertical', `swing-vertical-${accessory.context.device.deviceId}`, OscillationMode.Vertical);
+      this.swingHorizontalService = this.setupSwingDirectionSwitch(
+        'Swing Horizontal', `swing-horizontal-${accessory.context.device.deviceId}`, OscillationMode.Horizontal);
+    } else {
+      for (const name of ['Swing Vertical', 'Swing Horizontal']) {
+        const service = this.accessory.getService(name);
+        if (service) {
+          this.platform.log.debug(`Removing ${name}`);
+
+          this.accessory.removeService(service);
+        }
+      }
+    }
+
     // Warm the cache and start pushing state changes to HomeKit so values stay
     // fresh without every characteristic read hitting the API. Skipped when no
     // credentials are configured, to avoid spamming errors on cached accessories.
@@ -166,6 +193,37 @@ export class AirConditionerPlatformAccessory {
         }
       });
     }
+  }
+
+  private setupSwingDirectionSwitch(name: string, subtype: string, mode: OscillationMode): Service {
+    const service =
+      this.accessory.getService(name) ||
+      this.accessory.addService(this.platform.Service.Switch, name, subtype);
+
+    service.setCharacteristic(this.platform.Characteristic.Name, name);
+
+    service.getCharacteristic(this.platform.Characteristic.On)
+      .onGet(async () => {
+        const status = await this.requireStatus();
+        return this.computeOscillation(status) === mode;
+      })
+      .onSet(async (value) => {
+        const ok = await this.sendCommands([
+          {
+            capability: 'fanOscillationMode',
+            command: 'setFanOscillationMode',
+            arguments: [value ? mode : OscillationMode.Fixed],
+          },
+        ]);
+
+        if (!ok) {
+          this.platform.log.error(`Failed to set ${name}`);
+        } else {
+          this.scheduleRefresh();
+        }
+      });
+
+    return service;
   }
 
   private async handleWindFreeSwitchGet(): Promise<CharacteristicValue> {
@@ -423,6 +481,10 @@ export class AirConditionerPlatformAccessory {
     return displaySwitchStatus === SwitchState.On;
   }
 
+  private computeOscillation(status: DeviceStatus): OscillationMode {
+    return (this.readAttr(status, 'fanOscillationMode', 'fanOscillationMode') as OscillationMode) ?? OscillationMode.Fixed;
+  }
+
   // ---------------------------------------------------------------------------
   // Status fetching, caching and pushing
   // ---------------------------------------------------------------------------
@@ -490,6 +552,13 @@ export class AirConditionerPlatformAccessory {
       if (display !== undefined) {
         this.displaySwitchService.updateCharacteristic(chr.On, display);
       }
+    }
+
+    if ((this.swingVerticalService || this.swingHorizontalService) &&
+        this.readAttr(status, 'fanOscillationMode', 'fanOscillationMode') !== undefined) {
+      const mode = this.computeOscillation(status);
+      this.swingVerticalService?.updateCharacteristic(chr.On, mode === OscillationMode.Vertical);
+      this.swingHorizontalService?.updateCharacteristic(chr.On, mode === OscillationMode.Horizontal);
     }
   }
 


### PR DESCRIPTION
## What

Add an `OptionalSwingDirectionSwitches` config flag that exposes two switches — **Swing Vertical** and **Swing Horizontal** — to set the unit's swing direction via the `fanOscillationMode` capability. Turning a switch on selects that direction; turning it off falls back to `fixed`.

## Why

The Fanv2 `SwingMode` characteristic is only an on/off oscillation toggle; it can't pick a direction. On units that support directional oscillation, these switches expose vertical vs horizontal explicitly (and make them addressable from automations).

## How

- Opt-in (`OptionalSwingDirectionSwitches`, default `false`), consistent with the existing `Optional*` switches. When disabled the switches are removed, so existing setups are unaffected.
- Reads use the existing `readAttr` helper; writes go through `sendCommands` + `scheduleRefresh`, like the other switches. Both switches are refreshed on the background poll via `pushStatus`.

## Testing

- `tsc --noEmit` and `eslint --max-warnings=0` pass clean.
- Exercised on a live WindFree unit: each switch drives the correct oscillation direction and reflects the unit's state on the background poll.

## Note

Part of the same small series (fan, swing direction, auto-clean, humidity). Pairs naturally with the fan PR but stands alone. Happy to adjust naming or defaults to your preference.
