### PR TITLE
fix: fall back to optimistic display state on units that don't report it

### DIFF
--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -48,6 +48,9 @@ export class AirConditionerPlatformAccessory {
   private service: Service;
   private windFreeSwitchService?: Service;
   private displaySwitchService?: Service;
+  // Optimistic display state, used as a fallback for units that do not report
+  // the lighting capability. Updated whenever a real state is read or set.
+  private displayState = true;
 
   private temperatureUnit: TemperatureUnit = TemperatureUnit.Celsius;
 
@@ -205,7 +208,9 @@ export class AirConditionerPlatformAccessory {
     this.platform.log.debug('Triggered GET DisplaySwitch');
 
     const status = await this.requireStatus();
-    return this.expect(this.computeDisplay(status));
+    // Units that report the lighting capability give the real state; the rest
+    // don't report display state at all, so fall back to the last state we set.
+    return this.computeDisplay(status) ?? this.displayState;
   }
 
   private async handleDisplaySwitchSet(value: CharacteristicValue) {
@@ -226,6 +231,7 @@ export class AirConditionerPlatformAccessory {
     if (!ok) {
       this.platform.log.error('Failed to set DisplaySwitch');
     } else {
+      this.displayState = value as boolean;
       this.scheduleRefresh();
     }
   }
@@ -488,6 +494,7 @@ export class AirConditionerPlatformAccessory {
     if (this.displaySwitchService) {
       const display = this.computeDisplay(status);
       if (display !== undefined) {
+        this.displayState = display as boolean;
         this.displaySwitchService.updateCharacteristic(chr.On, display);
       }
     }


### PR DESCRIPTION
## What

Make the Display switch fall back to an optimistic last-known state on units that don't report their display state.

## Problem

`computeDisplay` reads `samsungce.airConditionerLighting.lighting`. Several Samsung WindFree units **don't expose that capability at all**, so `computeDisplay` returns `undefined` and `handleDisplaySwitchGet` (`expect(...)`) throws `SERVICE_COMMUNICATION_FAILURE` — the Display switch shows **"No Response"** on those units, even though the write path (`execute mode/vs/0`) works fine.

## Fix

Track the last display state we read or set (`displayState`) and use it as a fallback when the capability is absent:

- GET returns the real value when the unit reports `airConditionerLighting`, otherwise the last state we set.
- The value is updated on every successful SET and whenever a real state is read on the background poll.

Units that report the capability are unchanged (they keep the real state); units that don't now get a stable, controllable switch instead of a failing one.

## Testing

- `tsc --noEmit` and `eslint --max-warnings=0` pass clean.
- On a unit that does not report `airConditionerLighting`: the Display switch no longer shows "No Response", toggles correctly, and holds the state it was set to.

## Note

Small, self-contained behavior fix (9 lines). No config or API changes.
