### PR TITLE
fix: address review findings on status reads and OAuth token handling

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -12,6 +12,12 @@ export class HomebridgePlatform implements DynamicPlatformPlugin {
 
   public readonly tokenManager: TokenManager;
 
+  // A single 'shutdown' listener fans out to every accessory. Registering one
+  // listener per accessory trips Node's default max-listeners warning at 11
+  // devices, which looks like a leak in the Homebridge log.
+  private readonly shutdownHandlers: (() => void)[] = [];
+  private shutdownListenerRegistered = false;
+
   constructor(
     public readonly log: Logger,
     public readonly config: PlatformConfig,
@@ -34,6 +40,30 @@ export class HomebridgePlatform implements DynamicPlatformPlugin {
    */
   getAccessToken(): Promise<string> {
     return this.tokenManager.getAccessToken();
+  }
+
+  /**
+   * Registers a teardown callback to run when Homebridge shuts down. All
+   * callbacks share one underlying 'shutdown' listener.
+   */
+  onShutdown(handler: () => void): void {
+    this.shutdownHandlers.push(handler);
+
+    if (this.shutdownListenerRegistered) {
+      return;
+    }
+    this.shutdownListenerRegistered = true;
+
+    this.api.on('shutdown', () => {
+      for (const shutdownHandler of this.shutdownHandlers) {
+        try {
+          shutdownHandler();
+        } catch (error) {
+          this.log.debug('Shutdown handler failed:', (error as Error).message);
+        }
+      }
+      this.shutdownHandlers.length = 0;
+    });
   }
 
   configureAccessory(accessory: PlatformAccessory) {

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -44,6 +44,18 @@ const POLL_INTERVAL_MS = 15000;
 // refresh and push the resulting state.
 const REFRESH_AFTER_SET_MS = 1500;
 
+// How long to stop issuing status requests after SmartThings answers with a 429.
+// Used only when the response carries no usable Retry-After header.
+const RATE_LIMIT_BACKOFF_MS = 60000;
+
+// Upper bound on a server-supplied Retry-After, so a bogus value cannot wedge
+// the plugin for hours.
+const MAX_BACKOFF_MS = 15 * 60 * 1000;
+
+// Shorter pause after any other failed read, so a broken API or an expired
+// token does not turn the poll timer into a request flood.
+const ERROR_BACKOFF_MS = 30000;
+
 export class AirConditionerPlatformAccessory {
   private service: Service;
   private windFreeSwitchService?: Service;
@@ -54,7 +66,9 @@ export class AirConditionerPlatformAccessory {
   private cachedStatus: DeviceStatus | null = null;
   private statusFetchedAt = 0;
   private inFlightStatus: Promise<DeviceStatus | null> | null = null;
+  private backoffUntil = 0;
   private pollTimer?: NodeJS.Timeout;
+  private refreshTimer?: NodeJS.Timeout;
 
   public static readonly supportedCapabilities =
     [
@@ -160,9 +174,14 @@ export class AirConditionerPlatformAccessory {
         this.refreshAndPush().catch(() => { /* logged in fetch */ });
       }, POLL_INTERVAL_MS);
 
-      this.platform.api.on('shutdown', () => {
+      this.platform.onShutdown(() => {
         if (this.pollTimer) {
           clearInterval(this.pollTimer);
+          this.pollTimer = undefined;
+        }
+        if (this.refreshTimer) {
+          clearTimeout(this.refreshTimer);
+          this.refreshTimer = undefined;
         }
       });
     }
@@ -178,27 +197,33 @@ export class AirConditionerPlatformAccessory {
   private async handleWindFreeSwitchSet(value: CharacteristicValue) {
     this.platform.log.debug('Triggered SET WindFreeSwitch:', value);
 
-    const status = await this.getDeviceStatus();
+    // The decision below rejects the user's request, so it must not rest on a
+    // cache that can be seconds stale (or, after a failed read, arbitrarily
+    // old). Force a fresh read of the current mode.
+    const status = await this.getDeviceStatus(true);
+
+    if (!status) {
+      this.platform.log.error('Cannot set WindFreeSwitch: device status is unavailable');
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
+
     const airConditionerMode = this.readAttr(status, 'airConditionerMode', 'airConditionerMode') as AirConditionerMode | undefined;
 
     if (airConditionerMode === AirConditionerMode.Auto) {
-      this.platform.log.debug('WindFreeSwitch is not supported in Auto mode');
-      return;
+      // Report the rejection instead of silently dropping it: HomeKit would
+      // otherwise keep showing a switch position the AC never accepted.
+      this.platform.log.warn('WindFree is not supported in Auto mode; ignoring the requested change.');
+      this.pushStatus(status);
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.NOT_ALLOWED_IN_CURRENT_STATE);
     }
 
-    const ok = await this.sendCommands([
+    await this.runCommands('WindFreeSwitch', [
       {
         capability: 'custom.airConditionerOptionalMode',
         command: 'setAcOptionalMode',
         arguments: value ? [AirConditionerOptionalMode.WindFree] : [AirConditionerOptionalMode.Off],
       },
     ]);
-
-    if (!ok) {
-      this.platform.log.error('Failed to set WindFreeSwitch');
-    } else {
-      this.scheduleRefresh();
-    }
   }
 
   private async handleDisplaySwitchGet(): Promise<CharacteristicValue> {
@@ -211,7 +236,7 @@ export class AirConditionerPlatformAccessory {
   private async handleDisplaySwitchSet(value: CharacteristicValue) {
     this.platform.log.debug('Triggered SET DisplaySwitch:', value);
 
-    const ok = await this.sendCommands([
+    await this.runCommands('DisplaySwitch', [
       {
         capability: 'execute',
         command: 'execute',
@@ -222,12 +247,6 @@ export class AirConditionerPlatformAccessory {
         }],
       },
     ]);
-
-    if (!ok) {
-      this.platform.log.error('Failed to set DisplaySwitch');
-    } else {
-      this.scheduleRefresh();
-    }
   }
 
   private handleTemperatureDisplayUnitsGet(): CharacteristicValue {
@@ -289,13 +308,7 @@ export class AirConditionerPlatformAccessory {
       },
     ];
 
-    const ok = await this.sendCommands(commands);
-
-    if (!ok) {
-      this.platform.log.error('Failed to set TargetHeatingCoolingState');
-    } else {
-      this.scheduleRefresh();
-    }
+    await this.runCommands('TargetHeatingCoolingState', commands);
   }
 
   private async handleCurrentTemperatureGet(): Promise<CharacteristicValue> {
@@ -315,19 +328,13 @@ export class AirConditionerPlatformAccessory {
   private async handleTargetTemperatureSet(value: CharacteristicValue) {
     this.platform.log.debug('Triggered SET TargetTemperature:', value);
 
-    const ok = await this.sendCommands([
+    await this.runCommands('TargetTemperature', [
       {
         capability: 'thermostatCoolingSetpoint',
         command: 'setCoolingSetpoint',
         arguments: [value],
       },
     ]);
-
-    if (!ok) {
-      this.platform.log.error('Failed to set TargetTemperature');
-    } else {
-      this.scheduleRefresh();
-    }
   }
 
   // ---------------------------------------------------------------------------
@@ -493,10 +500,30 @@ export class AirConditionerPlatformAccessory {
     }
   }
 
+  /**
+   * Sends a set of commands and, on success, schedules the follow-up refresh.
+   * Throws a HAP error on failure so HomeKit reverts the control instead of
+   * showing a value the AC never accepted.
+   */
+  private async runCommands(what: string, commands: unknown[]): Promise<void> {
+    const ok = await this.sendCommands(commands);
+
+    if (!ok) {
+      this.platform.log.error(`Failed to set ${what}`);
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
+
+    this.scheduleRefresh();
+  }
+
   /** Invalidate the cache and schedule a fresh read once the command applied. */
   private scheduleRefresh(): void {
     this.statusFetchedAt = 0;
-    setTimeout(() => {
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+    }
+    this.refreshTimer = setTimeout(() => {
+      this.refreshTimer = undefined;
       this.refreshAndPush(true).catch(() => { /* logged in fetch */ });
     }, REFRESH_AFTER_SET_MS);
   }
@@ -505,21 +532,91 @@ export class AirConditionerPlatformAccessory {
    * Returns the device status, served from a short-lived cache and coalescing
    * concurrent callers into a single HTTP request. Never returns `undefined`;
    * on failure it returns the last-known status (or `null`).
+   *
+   * `forceRefresh` bypasses both the TTL and any request already in flight —
+   * see below for why joining one would be wrong.
    */
   private async getDeviceStatus(forceRefresh = false): Promise<DeviceStatus | null> {
-    if (!forceRefresh && this.cachedStatus && Date.now() - this.statusFetchedAt < STATUS_TTL_MS) {
-      return this.cachedStatus;
+    if (!forceRefresh) {
+      if (this.cachedStatus && Date.now() - this.statusFetchedAt < STATUS_TTL_MS) {
+        return this.cachedStatus;
+      }
+
+      // While backing off (see fetchDeviceStatus) serve the cache rather than
+      // adding to the load that triggered the backoff in the first place.
+      if (Date.now() < this.backoffUntil) {
+        return this.cachedStatus;
+      }
+
+      // An ordinary read is happy with whatever request is already running.
+      if (this.inFlightStatus) {
+        return this.inFlightStatus;
+      }
     }
 
-    if (this.inFlightStatus) {
-      return this.inFlightStatus;
-    }
+    // A forced read follows a command we just sent. A request already in flight
+    // was issued *before* that command, so its response describes the old state
+    // and would push the user's change straight back out of the Home app. Queue
+    // behind it instead of adopting its result.
+    const previous = this.inFlightStatus;
+    const request = (async () => {
+      if (previous) {
+        await previous.catch(() => undefined);
+      }
+      return this.fetchDeviceStatus();
+    })();
 
-    this.inFlightStatus = this.fetchDeviceStatus().finally(() => {
+    this.inFlightStatus = request;
+    // Settle handlers only; the promise itself is returned to (and awaited by)
+    // the caller, so this never swallows a rejection.
+    request.then(
+      () => this.clearInFlight(request),
+      () => this.clearInFlight(request),
+    );
+
+    return request;
+  }
+
+  private clearInFlight(request: Promise<DeviceStatus | null>): void {
+    if (this.inFlightStatus === request) {
       this.inFlightStatus = null;
-    });
+    }
+  }
 
-    return this.inFlightStatus;
+  /**
+   * Pauses status requests for a while after a failure. Without this the TTL
+   * cache stops suppressing requests exactly when the API is struggling: a
+   * failed fetch leaves `statusFetchedAt` untouched, so every characteristic
+   * read and every poll tick goes straight back to the network.
+   */
+  private backOff(durationMs: number, reason: string): void {
+    const until = Date.now() + durationMs;
+    if (until <= this.backoffUntil) {
+      return;
+    }
+    this.backoffUntil = until;
+    this.platform.log.warn(`Pausing device status requests for ${Math.round(durationMs / 1000)}s (${reason}).`);
+  }
+
+  /** Retry-After is either a delay in seconds or an HTTP date. */
+  private parseRetryAfter(response: Response): number | undefined {
+    const header = response.headers.get('retry-after');
+    if (!header) {
+      return undefined;
+    }
+
+    const seconds = Number(header);
+    if (Number.isFinite(seconds)) {
+      return seconds > 0 ? Math.min(seconds * 1000, MAX_BACKOFF_MS) : undefined;
+    }
+
+    const date = Date.parse(header);
+    if (Number.isNaN(date)) {
+      return undefined;
+    }
+
+    const delay = date - Date.now();
+    return delay > 0 ? Math.min(delay, MAX_BACKOFF_MS) : undefined;
   }
 
   private async fetchDeviceStatus(): Promise<DeviceStatus | null> {
@@ -530,13 +627,16 @@ export class AirConditionerPlatformAccessory {
       token = await this.platform.getAccessToken();
     } catch (error) {
       this.platform.log.error('Cannot get access token for device status:', (error as Error).message);
+      this.backOff(ERROR_BACKOFF_MS, 'no usable access token');
       return this.cachedStatus;
     }
 
     let response = await this.doStatusFetch(token);
 
     // A 401 usually means the token rotated/expired; refresh once and retry.
-    if (response && response.status === 401) {
+    // Only in OAuth mode: a PAT is static, so forceRefresh() would hand back the
+    // exact same token and the retry would replay the identical failing request.
+    if (response && response.status === 401 && this.platform.tokenManager.mode === 'oauth') {
       this.platform.log.warn('Device status returned 401; refreshing token and retrying.');
       try {
         token = await this.platform.tokenManager.forceRefresh();
@@ -547,13 +647,13 @@ export class AirConditionerPlatformAccessory {
     }
 
     if (!response) {
+      this.backOff(ERROR_BACKOFF_MS, 'network error');
       return this.cachedStatus;
     }
 
     if (response.status === 429) {
-      this.platform.log.warn(
-        'SmartThings rate limit hit (HTTP 429) while reading device status; using cached values and backing off.',
-      );
+      const backoff = this.parseRetryAfter(response) ?? RATE_LIMIT_BACKOFF_MS;
+      this.backOff(backoff, 'SmartThings rate limit, HTTP 429');
       return this.cachedStatus;
     }
 
@@ -565,6 +665,7 @@ export class AirConditionerPlatformAccessory {
           + 'A PAT created after 2024-12-30 expires 24h after creation — switch to OAuth to renew automatically.',
         );
       }
+      this.backOff(ERROR_BACKOFF_MS, `HTTP ${response.status}`);
       return this.cachedStatus;
     }
 
@@ -573,17 +674,20 @@ export class AirConditionerPlatformAccessory {
       data = await response.json();
     } catch {
       this.platform.log.error('Failed to parse device status response as JSON');
+      this.backOff(ERROR_BACKOFF_MS, 'unparseable response');
       return this.cachedStatus;
     }
 
     const main = data?.components?.main;
     if (!main) {
       this.platform.log.error('Device status response is missing components.main');
+      this.backOff(ERROR_BACKOFF_MS, 'response missing components.main');
       return this.cachedStatus;
     }
 
     this.cachedStatus = main;
     this.statusFetchedAt = Date.now();
+    this.backoffUntil = 0;
     return main;
   }
 
@@ -612,7 +716,8 @@ export class AirConditionerPlatformAccessory {
 
     let response = await this.doCommand(token, commands);
 
-    if (response && response.status === 401) {
+    // OAuth only — see the matching note in fetchDeviceStatus.
+    if (response && response.status === 401 && this.platform.tokenManager.mode === 'oauth') {
       this.platform.log.warn('Command returned 401; refreshing token and retrying.');
       try {
         token = await this.platform.tokenManager.forceRefresh();

--- a/src/tokenManager.ts
+++ b/src/tokenManager.ts
@@ -42,6 +42,7 @@ export class TokenManager {
   private expiresAt = 0;
 
   private loaded = false;
+  private loadPromise: Promise<void> | null = null;
   private refreshPromise: Promise<string> | null = null;
 
   constructor(
@@ -178,6 +179,11 @@ export class TokenManager {
     this.accessToken = data.access_token;
     this.expiresAt = Date.now() + (data.expires_in ?? DEFAULT_EXPIRES_IN_S) * 1000;
 
+    // We now hold the newest credentials, so nothing on disk can improve on
+    // them. Mark the load as done to stop a retried read (see loadPersisted)
+    // from overwriting them with an older snapshot.
+    this.loaded = true;
+
     // Refresh tokens rotate: persist the new one so it survives restarts.
     if (data.refresh_token && data.refresh_token !== this.refreshToken) {
       this.refreshToken = data.refresh_token;
@@ -190,32 +196,84 @@ export class TokenManager {
     return this.accessToken;
   }
 
+  /**
+   * Loads the persisted tokens once. The on-disk refresh token is the only copy
+   * of the current (rotated) credential, so a failed read must not be treated as
+   * "there is nothing stored" — that would silently fall back to the config
+   * value, which SmartThings already invalidated on the first rotation.
+   *
+   * Transient I/O errors therefore leave the manager unloaded so the next call
+   * retries. Only a successful read, a missing file, or unparseable content
+   * (which no amount of retrying will fix) mark the load as done.
+   */
   private async loadPersisted(): Promise<void> {
     if (this.loaded) {
       return;
     }
-    this.loaded = true;
+    // Coalesce concurrent loads into a single read.
+    if (!this.loadPromise) {
+      this.loadPromise = this.doLoadPersisted().finally(() => {
+        this.loadPromise = null;
+      });
+    }
+    return this.loadPromise;
+  }
 
+  private async doLoadPersisted(): Promise<void> {
+    let raw: string;
     try {
-      const raw = await fs.readFile(this.persistPath, 'utf8');
-      const persisted = JSON.parse(raw) as PersistedTokens;
-
-      // A persisted (rotated) refresh token always beats the stale config value.
-      if (persisted.refreshToken) {
-        this.refreshToken = persisted.refreshToken;
-      }
-      if (persisted.accessToken && persisted.expiresAt) {
-        this.accessToken = persisted.accessToken;
-        this.expiresAt = persisted.expiresAt;
-      }
+      raw = await fs.readFile(this.persistPath, 'utf8');
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
-      if (code !== 'ENOENT') {
-        this.log.warn('Could not read persisted OAuth tokens:', (error as Error).message);
+      if (code === 'ENOENT') {
+        // Nothing persisted yet: the config value is the right starting point.
+        this.loaded = true;
+        return;
       }
+      // Could be transient (EACCES during a permissions fix, EIO, ...). Keep the
+      // manager unloaded so a later call can still recover the stored token.
+      this.log.error(
+        `Could not read persisted OAuth tokens from ${this.persistPath}: ${(error as Error).message}. `
+        + 'Falling back to the RefreshToken from config for now; this will fail with invalid_grant if the '
+        + 'token has already rotated. Fix the file permissions and the stored token will be picked up again.',
+      );
+      return;
+    }
+
+    let persisted: PersistedTokens;
+    try {
+      persisted = JSON.parse(raw) as PersistedTokens;
+    } catch (error) {
+      // Unparseable content will not repair itself, so stop retrying — but be
+      // loud, because the stored refresh token is unrecoverable from here.
+      this.loaded = true;
+      this.log.error(
+        `Persisted OAuth token file ${this.persistPath} is corrupt (${(error as Error).message}). `
+        + 'Falling back to the RefreshToken from config; if that fails with invalid_grant, delete the file '
+        + 'and re-run the OAuth setup helper.',
+      );
+      return;
+    }
+
+    this.loaded = true;
+
+    // A persisted (rotated) refresh token always beats the stale config value.
+    if (persisted.refreshToken) {
+      this.refreshToken = persisted.refreshToken;
+    }
+    if (persisted.accessToken && persisted.expiresAt) {
+      this.accessToken = persisted.accessToken;
+      this.expiresAt = persisted.expiresAt;
     }
   }
 
+  /**
+   * Writes the tokens to disk atomically (temp file + fsync + rename) so a crash
+   * or a full disk can never leave a half-written file behind. This file holds
+   * the only valid refresh token after the first rotation, so a failure here is
+   * an error, not a warning: the plugin keeps working until the next restart and
+   * then cannot authenticate at all.
+   */
   private async persist(): Promise<void> {
     const data: PersistedTokens = {
       refreshToken: this.refreshToken,
@@ -223,10 +281,24 @@ export class TokenManager {
       expiresAt: this.expiresAt,
     };
 
+    const tmpPath = `${this.persistPath}.${process.pid}.tmp`;
+
     try {
-      await fs.writeFile(this.persistPath, JSON.stringify(data), { encoding: 'utf8', mode: 0o600 });
+      const handle = await fs.open(tmpPath, 'w', 0o600);
+      try {
+        await handle.writeFile(JSON.stringify(data), 'utf8');
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+      await fs.rename(tmpPath, this.persistPath);
     } catch (error) {
-      this.log.warn('Could not persist OAuth tokens to disk:', (error as Error).message);
+      this.log.error(
+        `Could not persist OAuth tokens to ${this.persistPath}: ${(error as Error).message}. `
+        + 'The rotated refresh token exists only in memory — if Homebridge restarts before this succeeds, '
+        + 'you will have to re-run the OAuth setup helper to obtain a new RefreshToken.',
+      );
+      await fs.rm(tmpPath, { force: true }).catch(() => { /* best effort */ });
     }
   }
 }


### PR DESCRIPTION
Follow-up to #29, which is already merged. These are the seven behavioral issues found reviewing it, plus two related cleanups.

## Status reads (`src/platformAccessory.ts`)

**Forced refresh adopted a pre-command response.** `getDeviceStatus(forceRefresh = true)` skipped the TTL check but still returned an in-flight fetch. That request was issued *before* the command we just sent, so the post-command `scheduleRefresh` pushed pre-command state and visibly reverted the user's change in the Home app. Forced reads now queue behind the pending request and issue their own; chaining rather than racing also guarantees the forced fetch writes the cache last. Ordinary reads still coalesce into a single request.

**Failures did not back off.** 429 and every other failure path returned the cached status without updating `statusFetchedAt`, so the TTL cache stopped suppressing requests exactly when the API was rate-limiting — and the "backing off" log line was untrue. Added a backoff gate: 429 honours `Retry-After` (seconds or HTTP-date, clamped to 15 min, default 60s), other failures pause reads for 30s, and a successful read clears it. The log now states the actual duration and reason.

**The 401 retry was pointless in PAT mode.** `forceRefresh()` returns the same static token for a PAT, so the retry replayed an identical failing request. Both sites (status reads and commands) are now gated on `mode === 'oauth'`.

**WindFree set decided from a stale cache.** `handleWindFreeSwitchSet` read the mode from a cache that can be up to 4s stale — or arbitrarily old after a failed read — and silently no-opped on `auto`, leaving HomeKit showing a state the AC never accepted. It now forces a fresh read before rejecting, and reports the rejection as `NOT_ALLOWED_IN_CURRENT_STATE` after re-pushing the real state.

## Token persistence (`src/tokenManager.ts`)

**`loadPersisted` latched `loaded` before the read.** One non-ENOENT read failure permanently discarded the rotated refresh token and fell back to the already-invalidated config value — `invalid_grant` forever. The flag is now set only on success, ENOENT, or unparseable content; transient I/O errors leave the manager unloaded so a later call retries and recovers the stored token. Concurrent loads are coalesced, and a successful refresh marks the load done so a retried read cannot clobber newer in-memory tokens with an older snapshot.

**A `persist()` failure was only a warning.** After the first rotation this file holds the only copy of the still-valid refresh token, so the plugin kept working and then died silently at the next restart. Now an atomic write (temp file + `fsync` + `rename`, mode 0600) with an error-level log naming the file and the consequence, and the temp file is cleaned up on failure.

## Lifecycle (`src/platform.ts`)

One `api.on('shutdown', …)` listener per accessory tripped Node's `MaxListenersExceededWarning` at 11+ devices, which reads as a leak in the Homebridge log. Accessories now register teardown through a single platform-level listener. The post-command refresh timer is cleared on shutdown too.

## Two changes beyond the review findings

- **Failed commands now surface as HAP errors in every setter**, not just WindFree. The `if (!ok) log.error(...)` pattern was the same defect in three other places, so it is extracted into a `runCommands` helper. Worth calling out because it changes Home app behavior on failure: the control visibly reverts instead of silently sticking on a value the AC never accepted.
- The post-command refresh `setTimeout` is tracked so it can be cleared.

## Testing

`tsc --noEmit` and `npm run lint` both pass.

The repo has no test framework, so I verified behavior with two throwaway harnesses (not committed) driving the compiled output against stubbed HAP objects and a faked `fetch` — 45 assertions, all passing. They cover each finding plus the regressions that mattered: ordinary reads still coalesce into one request, non-auto WindFree sets still send the command, `Retry-After` parsing and clamping, atomic-write leaves no temp file at mode 0600, and no `MaxListenersExceededWarning` at 25 accessories.

Not covered: the real SmartThings API, and `fsync` durability under actual power loss.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXdaxpWV7ViH5TchorttUQ)_