### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-samsung-windfree-ac",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-samsung-windfree-ac",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "bin": {
         "homebridge-samsung-windfree-ac-auth": "bin/oauth-setup.mjs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Samsung WindFree AC",
   "name": "homebridge-samsung-windfree-ac",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Homebridge plugin for Samsung WindFree AC.",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
Version bump for the 1.2.0 release.

`v.1.1.3` points at `5004d75`, so everything merged since then is unreleased — both #29 (OAuth2 authentication) and #36 (the review fixes). npm `latest` is still 1.1.3, and `npm publish` would fail outright if the release were cut without this bump, since a published version can never be republished.

Minor rather than patch because 1.1.3 had no OAuth2 support at all: this span adds `src/tokenManager.ts`, the `homebridge-samsung-windfree-ac-auth` CLI binary, and new `config.schema.json` fields.

Touches `package.json` and `package-lock.json` only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXdaxpWV7ViH5TchorttUQ)_