### PR TITLE
feat: expose dry (dehumidify) mode as an optional switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Configuration parameters:
 - `OptionalWindFreeSwitch`: expose a switch for WindFree mode.
 - `OptionalDisplaySwitch`: expose a switch for the display light.
 - `IgnoredDevices`: list of SmartThings device IDs or names to hide from HomeKit.
+- `OptionalDryModeSwitch`: expose a switch for dry (dehumidify) mode.
 - `OptionalHumiditySensor`: expose the indoor relative humidity as a separate sensor.
 - `OptionalFanControl`: expose a fan with speed, auto/manual and swing on/off.
 - `OptionalSwingDirectionSwitches`: expose switches for vertical/horizontal swing direction.
@@ -170,7 +171,14 @@ device status` errors. On an expired/invalid token you will see a clear HTTP
 ## Supported Optional Modes
 - `windFree`
 > To enable this mode, you need to select the `windFree` option in the plugin settings.
+- `dry`
+> HomeKit thermostats only understand off/cool/heat/auto, so dry mode is exposed as a separate
+> switch instead (enable `OptionalDryModeSwitch`). Turning it on puts the unit into dry mode,
+> powering it on first if needed; turning it off returns the unit to the mode it was in before —
+> including a mode you selected from the remote or the SmartThings app. While the unit is drying,
+> the thermostat tile itself reads as off, since HomeKit has no state to show for it.
 
 ## Roadmap
 - [x] Add support for `windFree` mode.
+- [x] Add support for `dry` mode.
 - [ ] Add automated tests and CI/CD.

--- a/config.schema.json
+++ b/config.schema.json
@@ -78,6 +78,12 @@
         "description": "Ignored on units that do not report custom.autoCleaningMode.",
         "type": "boolean",
         "default": false
+      },
+      "OptionalDryModeSwitch": {
+        "title": "Expose a switch to enable/disable dry (dehumidify) mode",
+        "description": "HomeKit thermostats have no dry state, so dry mode is exposed as a switch. Turning it off returns the unit to the mode it was in before.",
+        "type": "boolean",
+        "default": false
       }
     },
     "required": ["name", "BaseURL"]

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -88,6 +88,7 @@ export class AirConditionerPlatformAccessory {
   private windFreeSwitchService?: Service;
   private displaySwitchService?: Service;
   private humiditySensorService?: Service;
+  private dryModeSwitchService?: Service;
   private fanService?: Service;
   private swingVerticalService?: Service;
   private swingHorizontalService?: Service;
@@ -106,6 +107,11 @@ export class AirConditionerPlatformAccessory {
   // RotationSpeed slider something meaningful to show while in Auto and to pick
   // a speed when HomeKit switches the fan back to manual.
   private lastManualFanMode: FanMode = FanMode.Medium;
+
+  // Mode to go back to when the dry switch is turned off. HomeKit has no "dry"
+  // target state, so the switch has to restore whatever the unit was doing
+  // before. Tracks the last non-dry mode seen on the unit.
+  private modeBeforeDry: AirConditionerMode = AirConditionerMode.Cool;
 
   private cachedStatus: DeviceStatus | null = null;
   private statusFetchedAt = 0;
@@ -305,6 +311,28 @@ export class AirConditionerPlatformAccessory {
       this.removeServiceByName('Auto Clean');
     }
 
+    this.platform.log.debug('Optional Dry Mode Switch: ', this.platform.config.OptionalDryModeSwitch);
+    if (this.platform.config.OptionalDryModeSwitch) {
+      this.platform.log.debug('Adding Dry Mode Switch');
+
+      this.dryModeSwitchService =
+      this.accessory.getService('Dry') ||
+      this.accessory.addService(this.platform.Service.Switch, 'Dry', `dry-${accessory.context.device.deviceId}`);
+
+      this.dryModeSwitchService.setCharacteristic(this.platform.Characteristic.Name, 'Dry');
+
+      this.dryModeSwitchService.getCharacteristic(this.platform.Characteristic.On)
+        .onGet(this.handleDryModeSwitchGet.bind(this))
+        .onSet(this.handleDryModeSwitchSet.bind(this));
+    } else {
+      const dryModeSwitchService = this.accessory.getService('Dry');
+      if (dryModeSwitchService) {
+        this.platform.log.debug('Removing Dry Mode Switch');
+
+        this.accessory.removeService(dryModeSwitchService);
+      }
+    }
+
     // Warm the cache and start pushing state changes to HomeKit so values stay
     // fresh without every characteristic read hitting the API. Skipped when no
     // credentials are configured, to avoid spamming errors on cached accessories.
@@ -424,6 +452,68 @@ export class AirConditionerPlatformAccessory {
         arguments: value ? [AirConditionerOptionalMode.WindFree] : [AirConditionerOptionalMode.Off],
       },
     ]);
+  }
+
+  private async handleDryModeSwitchGet(): Promise<CharacteristicValue> {
+    this.platform.log.debug('Triggered GET DryModeSwitch');
+
+    const status = await this.requireStatus();
+    return this.expect(this.computeDryMode(status));
+  }
+
+  private async handleDryModeSwitchSet(value: CharacteristicValue) {
+    this.platform.log.debug('Triggered SET DryModeSwitch:', value);
+
+    // Every decision below is relative to the mode the unit is in now, so it
+    // must not rest on a possibly stale cache.
+    const status = await this.requireFreshStatus('DryModeSwitch');
+
+    const airConditionerMode = this.readAttr(status, 'airConditionerMode', 'airConditionerMode') as AirConditionerMode | undefined;
+
+    // Acting on an unknown mode would either strand the unit in dry or knock it
+    // out of the mode the user actually chose.
+    if (airConditionerMode === undefined) {
+      this.platform.log.error('Cannot set DryModeSwitch: the current mode is unknown');
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
+
+    const targetMode = value ? AirConditionerMode.Dry : this.modeBeforeDry;
+
+    if (airConditionerMode === targetMode) {
+      this.platform.log.debug('Dry mode is already', value ? 'on' : 'off');
+      return;
+    }
+
+    // Turning the switch off only means anything while the unit is drying.
+    if (!value && airConditionerMode !== AirConditionerMode.Dry) {
+      this.platform.log.debug('Unit is not in dry mode; leaving the mode alone');
+      return;
+    }
+
+    const supportedModes = this.readAttr(status, 'airConditionerMode', 'supportedAcModes');
+    if (Array.isArray(supportedModes) && !supportedModes.includes(targetMode)) {
+      this.rejectRequest(`${this.name} does not support the ${targetMode} mode; ignoring the requested change.`, status);
+    }
+
+    if (value) {
+      this.modeBeforeDry = airConditionerMode;
+    }
+
+    const commands: unknown[] = [];
+
+    // Dry mode on a powered-off unit has to power it on, otherwise the command
+    // is accepted and nothing happens.
+    if (value && this.readAttr(status, 'switch', 'switch') !== SwitchState.On) {
+      commands.push({ capability: 'switch', command: SwitchState.On });
+    }
+
+    commands.push({
+      capability: 'airConditionerMode',
+      command: 'setAirConditionerMode',
+      arguments: [targetMode],
+    });
+
+    await this.runCommands('DryModeSwitch', commands);
   }
 
   private async handleDisplaySwitchGet(): Promise<CharacteristicValue> {
@@ -871,6 +961,16 @@ export class AirConditionerPlatformAccessory {
     return windFreeSwitchStatus === AirConditionerOptionalMode.WindFree;
   }
 
+  private computeDryMode(status: DeviceStatus): CharacteristicValue | undefined {
+    const airConditionerMode = this.readAttr(status, 'airConditionerMode', 'airConditionerMode') as AirConditionerMode | undefined;
+
+    if (airConditionerMode === undefined) {
+      return undefined;
+    }
+
+    return airConditionerMode === AirConditionerMode.Dry;
+  }
+
   private computeDisplay(status: DeviceStatus): CharacteristicValue | undefined {
     const displaySwitchStatus = this.readAttr(status, LIGHTING_CAPABILITY, 'lighting') as SwitchState | undefined;
 
@@ -1164,6 +1264,20 @@ export class AirConditionerPlatformAccessory {
       const horizontal = this.computeSwingDirection(status, OscillationMode.Horizontal);
       if (horizontal !== undefined) {
         this.swingHorizontalService.updateCharacteristic(chr.On, horizontal);
+      }
+    }
+
+    // Remember where to put the unit back when dry mode is switched off, even
+    // when the mode was changed from the remote or the SmartThings app.
+    const airConditionerMode = this.readAttr(status, 'airConditionerMode', 'airConditionerMode') as AirConditionerMode | undefined;
+    if (airConditionerMode !== undefined && airConditionerMode !== AirConditionerMode.Dry) {
+      this.modeBeforeDry = airConditionerMode;
+    }
+
+    if (this.dryModeSwitchService) {
+      const dryMode = this.computeDryMode(status);
+      if (dryMode !== undefined) {
+        this.dryModeSwitchService.updateCharacteristic(chr.On, dryMode);
       }
     }
   }


### PR DESCRIPTION
Fixes #16

## Why a switch

HomeKit's `TargetHeatingCoolingState` only has off/cool/heat/auto — there is no "dry" value to map `airConditionerMode: 'dry'` onto. So dry mode is exposed the same way WindFree already is: an optional switch behind a new `OptionalDryModeSwitch` config flag (default `false`), refreshed on the existing background poll.

## Behaviour

- **On** → sends `setAirConditionerMode dry`, prefixed with `switch on` when the unit is off, so the command can't be accepted while nothing actually happens.
- **Off** → restores the mode the unit was in *before* dry. That mode is tracked from the background poll, so a mode picked up on the remote or in the SmartThings app is restored too, rather than a hardcoded default. It falls back to `cool` only if nothing has ever been observed.
- Writes that would change nothing are dropped: switching on while already drying, and switching off while the unit is in some other mode (which would otherwise knock it out of the mode the user just chose).
- A mode the unit doesn't list in `supportedAcModes` is never requested.
- An unreadable status aborts the write instead of guessing — both directions are relative to the current mode, so acting on an unknown one could strand the unit in dry.

Follows the existing `readAttr` / `compute*` / `expect` and `sendCommands` / `scheduleRefresh` patterns; `computeDryMode` returns `undefined` when the mode is missing, so reads surface as a communication failure like every other characteristic.

## One thing worth knowing

While the unit is drying, the thermostat tile itself reads as **off** — `computeTargetHeatingCoolingState` has always mapped `dry`/`wind` to `OFF`, and HomeKit has no better state to show. This is documented in the README rather than changed, since altering that mapping affects units in dry mode regardless of this switch. Happy to address it separately if you'd prefer the tile show something else.

## Verification

`tsc --noEmit` and `eslint --max-warnings=0` pass. Behaviour checked against a stub SmartThings unit (fake status payloads, recorded commands, real `hap-nodejs` services) covering all 11 cases above — on from heat then off restores heat, restores a mode changed on the remote, powers on when off, both echoed-write no-ops, unsupported `dry` and unreadable status. The harness was throwaway and isn't in the diff; the repo has no test infrastructure and adding it wasn't part of this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZNThQUtsW1xnSPNn6PLDq)_