### PR TITLE
feat: let users hide devices from HomeKit with IgnoredDevices

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ Configuration parameters:
 - `ClientID` / `ClientSecret` / `RefreshToken`: OAuth auth (Option B).
 - `OptionalWindFreeSwitch`: expose a switch for WindFree mode.
 - `OptionalDisplaySwitch`: expose a switch for the display light.
+- `IgnoredDevices`: list of SmartThings device IDs or names to hide from HomeKit.
+
+### Hiding devices
+
+By default every compatible air conditioner on the account is added to HomeKit. To leave some out,
+list them in `IgnoredDevices` by device ID or by name (case-insensitive):
+
+```json
+{
+    "platform": "Homebridge Samsung WindFree AC",
+    "name": "Samsung WindFree AC",
+    "BaseURL": "https://api.smartthings.com/v1/",
+    "AccessToken": "your_access_token",
+    "IgnoredDevices": ["Guest Room AC", "a1b2c3d4-0000-1111-2222-333344445555"]
+}
+```
+
+Both identifiers are printed for every discovered device in the Homebridge log (enable debug mode
+for the full list). Prefer the device ID — names change when you rename a device in the SmartThings
+app. Adding a device that is already in HomeKit removes its accessory on the next restart.
 
 Sample configuration (PAT):
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -45,6 +45,15 @@
         "title": "Expose a switch to turn on/off the display light",
         "type": "boolean",
         "default": false
+      },
+      "IgnoredDevices": {
+        "title": "Devices to hide from HomeKit",
+        "description": "SmartThings device IDs or names to skip during discovery. Matching is case-insensitive. The device ID is the most reliable, since names change; both are printed in the Homebridge log at startup.",
+        "type": "array",
+        "items": {
+          "title": "Device ID or name",
+          "type": "string"
+        }
       }
     },
     "required": ["name", "BaseURL"]

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -18,6 +18,9 @@ export class HomebridgePlatform implements DynamicPlatformPlugin {
   private readonly shutdownHandlers: (() => void)[] = [];
   private shutdownListenerRegistered = false;
 
+  /** Device IDs and labels to skip, normalized for case-insensitive matching. */
+  private readonly ignoredDevices: string[];
+
   constructor(
     public readonly log: Logger,
     public readonly config: PlatformConfig,
@@ -25,6 +28,8 @@ export class HomebridgePlatform implements DynamicPlatformPlugin {
 
   ) {
     this.log.debug('Finished initializing platform:', this.config.name);
+
+    this.ignoredDevices = this.parseIgnoredDevices(this.config.IgnoredDevices);
 
     this.tokenManager = new TokenManager(this.log, this.config, this.api.user.storagePath());
 
@@ -144,10 +149,19 @@ export class HomebridgePlatform implements DynamicPlatformPlugin {
     for (const device of data.items) {
       const uuid = this.api.hap.uuid.generate(device.deviceId);
 
+      if (this.isDeviceIgnored(device)) {
+        this.log.info('Ignoring device (listed in IgnoredDevices):', device.label);
+
+        this.removeCachedAccessory(uuid);
+        continue;
+      }
+
       const capabilities = device.components[0].capabilities
         .map((capability: { id: string }) => capability.id);
 
-      this.log.debug('Discovered device:', device.label, capabilities);
+      // The device ID is logged alongside the name so it can be copied into
+      // IgnoredDevices, which is the identifier that survives a rename.
+      this.log.debug('Discovered device:', device.label, device.deviceId, capabilities);
 
       if (!this.doesDeviceSupportCapabilities(capabilities)) {
         this.log.warn('Device has unsupported capabilities:', device.label);
@@ -172,6 +186,66 @@ export class HomebridgePlatform implements DynamicPlatformPlugin {
         this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
       }
     }
+  }
+
+  /**
+   * Reads the `IgnoredDevices` config entry, dropping anything that isn't a
+   * usable string so one bad entry can't take discovery down with it.
+   */
+  private parseIgnoredDevices(configured: unknown): string[] {
+    if (configured === undefined || configured === null) {
+      return [];
+    }
+
+    if (!Array.isArray(configured)) {
+      this.log.warn('IgnoredDevices must be a list of device IDs or names; ignoring it.');
+      return [];
+    }
+
+    const ignored = configured
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map(entry => entry.trim().toLowerCase())
+      .filter(entry => entry !== '');
+
+    if (ignored.length !== configured.length) {
+      this.log.warn('IgnoredDevices contains entries that are not text; those were skipped.');
+    }
+
+    if (ignored.length > 0) {
+      this.log.debug('Ignoring devices matching:', ignored);
+    }
+
+    return ignored;
+  }
+
+  /** Matches a device against `IgnoredDevices` by device ID or by name. */
+  private isDeviceIgnored(device: { deviceId?: string; label?: string; name?: string }): boolean {
+    if (this.ignoredDevices.length === 0) {
+      return false;
+    }
+
+    return [device.deviceId, device.label, device.name]
+      .filter((value): value is string => typeof value === 'string')
+      .some(value => this.ignoredDevices.includes(value.trim().toLowerCase()));
+  }
+
+  /**
+   * Drops an accessory HomeKit already knows about. Without this, a device
+   * added to `IgnoredDevices` would keep its (now unmanaged) tile in the Home
+   * app until the user removed it by hand.
+   */
+  private removeCachedAccessory(uuid: string): void {
+    const index = this.accessories.findIndex(accessory => accessory.UUID === uuid);
+
+    if (index === -1) {
+      return;
+    }
+
+    const [accessory] = this.accessories.splice(index, 1);
+
+    this.log.info('Removing accessory from HomeKit:', accessory.displayName);
+
+    this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
   }
 
   doesDeviceSupportCapabilities(capabilities: string[]): boolean {


### PR DESCRIPTION
Fixes #27

Every compatible air conditioner on the SmartThings account was added to HomeKit unconditionally. `IgnoredDevices` takes a list of device IDs or names and skips them during discovery, alongside the existing capability filter in `src/platform.ts`.

```json
"IgnoredDevices": ["Guest Room AC", "a1b2c3d4-0000-1111-2222-333344445555"]
```

## Details

- **Either identifier works.** Users can start from the name they see in the SmartThings app and move to the device ID (which survives a rename) when they want. Matching is case-insensitive and trims whitespace.
- **The device ID is now logged** next to the name during discovery — previously only the label was, so there was nowhere to copy the ID from.
- **Already-registered devices are unregistered** when added to the list. Without this, adding a device to `IgnoredDevices` would leave an orphaned tile in the Home app that nothing updates, and the user would have to remove it by hand.
- **Malformed config is survivable.** A string instead of a list, or entries that aren't text, get a warning and are skipped rather than breaking discovery for every device.

Went with the opt-out `IgnoredDevices` rather than an opt-in `IncludedDevices` so existing installs keep working untouched with no config change.

## Not covered

The issue also floats *"maybe be able to select by home like in the smart things app"*. Filtering by SmartThings location would need the `locationId` from the device payload and a way for users to discover location IDs — a bigger change with its own config surface. Left out to keep this scoped; happy to follow up if you want it.

## Verification

`tsc --noEmit` and `eslint --max-warnings=0` pass. Behaviour checked against a stub SmartThings `/devices` response covering all 14 cases: no filter, name filter, ID filter with mixed case and padding, mixed identifiers, cached-accessory removal, a non-ignored cached accessory being left alone, and the three malformed-config shapes. The harness was throwaway and isn't in the diff; the repo has no test infrastructure and adding it wasn't part of this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZNThQUtsW1xnSPNn6PLDq)_