### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-samsung-windfree-ac",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-samsung-windfree-ac",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "bin": {
         "homebridge-samsung-windfree-ac-auth": "bin/oauth-setup.mjs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Samsung WindFree AC",
   "name": "homebridge-samsung-windfree-ac",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Homebridge plugin for Samsung WindFree AC.",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
Version bump for the 1.3.0 release.

`v1.2.0` points at `d664dfd`, which was tagged a couple of hours *before* #38, #39 and #40 merged — so all three are on `main` but not on npm, and the reporters on #9 and #35 can't yet get the fixes they were told about. `npm publish` would also fail outright if the release were cut without this bump, since 1.2.0 is already published.

## Why minor, not patch

Every unreleased change is additive:

| PR | What it adds |
| --- | --- |
| #40 | `OptionalHumiditySensor`, `OptionalFanControl`, `OptionalSwingDirectionSwitches`, `OptionalAutoCleanSwitch` — plus the display-state fallback from @RJLino's #34 |
| #38 | `OptionalDryModeSwitch` |
| #39 | `IgnoredDevices` discovery filter |

That's six new opt-in config flags and four new HomeKit services (`Fanv2`, `HumiditySensor`, and the swing/auto-clean/dry switches). All default to `false` and are gated on the capabilities the unit actually advertises, so existing configurations are unaffected — but a patch bump would understate the scope in the Homebridge UI.

Also in this span, without user-facing effect: `912e08d` moves npm publishing to trusted publishing (OIDC) instead of a static `NPM_ACCESS_TOKEN`, and `c65e358` adds job timeouts and a `workflow_dispatch` re-run path to the publish workflow.

## Issues this releases

- #9 — fan speed and oscillation (and dry mode, from the follow-up comments)
- #35 — Display switch reporting "No Response" on units without `samsungce.airConditionerLighting`
- #16, #27 — already closed by #38 and #39

## Verification

`npm ci`, `npm run lint` and `npm run build` all pass at 1.3.0. Touches `package.json` and `package-lock.json` only — no source changes.

Once this merges I'll tag `v1.3.0`, which fires the publish workflow.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkpmNS8Uw3JgmTQ2iexKXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkpmNS8Uw3JgmTQ2iexKXF)_