### PR TITLE
ci: stop mutating the lockfile during the build check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Lint the project
         run: npm run lint
@@ -29,10 +29,11 @@ jobs:
       - name: Build the project
         run: npm run build
 
-      - name: List, audit, fix outdated dependencies and build again
+      # Report only. This step must never write to package-lock.json: a fix
+      # applied here is invisible to the committed tree, so anything it changed
+      # would be gone by the next run while making this one look clean.
+      # Failures are ignored so an upstream advisory cannot block an unrelated PR.
+      - name: Report outdated and vulnerable dependencies
         run: |
-          npm list --outdated
-          npm audit || true  # ignore failures
-          npm audit fix || true
-          npm list --outdated
-          npm run build
+          npm outdated || true
+          npm audit || true


### PR DESCRIPTION
The build job ran `npm audit fix` and then rebuilt, so the build gating a PR was not the build of the committed lockfile — it was a build against a tree npm had rewritten in the runner. Whatever the fix changed was discarded when the job ended, so the same advisories were re-fixed and re-thrown-away on every run while the check reported green.

```diff
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Lint the project
         run: npm run lint
 
       - name: Build the project
         run: npm run build
 
-      - name: List, audit, fix outdated dependencies and build again
+      - name: Report outdated and vulnerable dependencies
         run: |
-          npm list --outdated
-          npm audit || true  # ignore failures
-          npm audit fix || true
-          npm list --outdated
-          npm run build
+          npm outdated || true
+          npm audit || true
```

Four changes, all the same defect:

- **`npm audit fix` is gone.** It was the only thing writing to `package-lock.json` mid-job.
- **`npm install` → `npm ci`.** Same problem from the other end: `npm ci` installs exactly what the lockfile pins and fails if it has drifted from `package.json`, which is the property a gating check needs. `npm install` is free to resolve something else and update the lockfile.
- **The second `npm run build` goes away** with the mutation it existed to re-verify.
- **`npm list --outdated` → `npm outdated`.** The old form was not a real command — `--outdated` belongs to `npm outdated`, so `npm list` ignored the flag and printed the dependency tree. That step never did what its name said.

The audit stays, as a report-only step. It still surfaces advisories in the log, but it cannot write to the lockfile, and its failures stay non-fatal so an upstream advisory in a dev dependency cannot block an unrelated PR.

## What the audit now reports

Previously invisible, because `npm audit fix` "resolved" it every run: **9 advisories — 7 high, 1 moderate, 1 low**, in `@isaacs/brace-expansion`, `brace-expansion`, `flatted`, `glob`, `js-yaml`, `minimatch`, `picomatch`, `ajv` and `diff`.

All are in `devDependencies` — npm counts 299 dev and 1 prod (the package itself). The plugin has no runtime dependencies, so none of this reaches users through the published tarball; they are transitive deps of eslint, rimraf, nodemon and the dev-only homebridge. Nothing here is urgent, and updating them is deliberately not part of this change.

## Verification

Ran the exact new step sequence locally against this branch: `npm ci`, `npm run lint` and `npm run build` all exit 0, `npm outdated` and `npm audit` report as above without failing the step, and `package-lock.json` is byte-identical afterwards — which is the whole point of the change. Touches `.github/workflows/build.yml` only.

## Not covered

`actions/checkout@v3` and `actions/setup-node@v3` are a major version behind what `npm.yml` already uses, and this job has no `cache: npm`. Both are worth doing, but they are unrelated to the lockfile mutation and would muddy the diff — happy to follow up separately.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkpmNS8Uw3JgmTQ2iexKXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkpmNS8Uw3JgmTQ2iexKXF)_