### PR TITLE
chore: bump version to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-samsung-windfree-ac",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-samsung-windfree-ac",
-      "version": "1.3.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "bin": {
         "homebridge-samsung-windfree-ac-auth": "bin/oauth-setup.mjs"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Samsung WindFree AC",
   "name": "homebridge-samsung-windfree-ac",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Homebridge plugin for Samsung WindFree AC.",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
Version bump for the 2.0.0 release.

## Why major

`engines.node` narrowed from `^20 || ^22 || ^24` to `^22 || ^24 || ^26` in b031d0a and 4f4764f. Node 20 reached end of life in April 2026, so dropping it is defensible on the merits — but it still makes this release uninstallable for anyone who has not moved off it, and Homebridge reports an engine mismatch as a hard failure rather than a warning. That is a breaking change to who can run the plugin, which is what a major is for.

Worth being explicit that this is *not* a rewrite: **the plugin's runtime behaviour is byte-identical to 1.3.0.** No source file changed in this span. Anyone already on Node 22+ can upgrade with no config change and see no difference.

## What is in the release

| Commit | Change | Reaches users? |
| --- | --- | --- |
| b031d0a, 4f4764f | `engines.node` → `^22 \|\| ^24 \|\| ^26`; CI matrix now 22.x / 24.x / 26.x | **Yes** — this is the breaking part |
| e16c71f | Dependency majors: eslint 9→10, typescript 5→6, `@types/node` 24→26, homebridge devDep 1→2 | No — all `devDependencies` |
| 66c8b10 | Build check no longer mutates the lockfile mid-run (#42) | No — CI only |

The published package still has **no runtime dependencies**, so the dependency majors change nothing in the tarball users install.

## On `typescript`

Held at `^6.0.3` deliberately. TypeScript 7 compiles this project fine, but `@typescript-eslint/parser` refuses to load against it:

```
typescript-eslint does not support TS 7.0.
See https://github.com/typescript-eslint/typescript-eslint/issues/10940
```

That is a hard version guard, not a fixable type error, so taking TS 7 would mean dropping typed linting entirely. `^6.0.3` is the right ceiling until typescript-eslint ships TS 7.1 support.

## Verification

`npm ci`, `npm run lint` and `npm run build` all pass at 2.0.0, and `npm audit` reports **0 vulnerabilities** (down from 9 before e16c71f). Version is consistent across `package.json`, the lockfile root, and `packages[""]`. Touches `package.json` and `package-lock.json` only — no source changes.

## Note for whoever cuts the release

`v1.3.0` published successfully, so this bump is required before tagging: npm permanently refuses a republished version.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkpmNS8Uw3JgmTQ2iexKXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkpmNS8Uw3JgmTQ2iexKXF)_