### PR TITLE
ci: move actions to v5 so they run on Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
         node-version: [22.x, 24.x, 26.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }} 
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22.x'
           cache: npm
@@ -43,10 +43,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22.x'
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
Clears the runner warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-node@v4`
> https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

The v3 and v4 releases of these actions declare a Node 20 runtime in their `action.yml`. Runners no longer provide Node 20, so they are force-upgraded to Node 24 and the warning is emitted. The v5 line declares `node24` directly, so both the forced upgrade and the warning go away.

## Changed

| File | Job | Before | After |
| --- | --- | --- | --- |
| `npm.yml` | `build` | `checkout@v4`, `setup-node@v4` | `@v5` |
| `npm.yml` | `publish-npm` | `checkout@v4`, `setup-node@v4` | `@v5` |
| `build.yml` | `build` | `checkout@v3`, `setup-node@v3` | `@v5` |

The warning only named the `@v4` pair in `npm.yml`, since that is the workflow whose log you were reading. `build.yml` was on `@v3` — a release older still, with the same Node 20 runtime — so it is fixed here too rather than left to produce the identical warning on the next PR.

## Scope

This changes only the Node version **the actions' own code** runs under. It does not touch:

- `node-version` in `setup-node`, which selects the Node the project builds against — still `[22.x, 24.x, 26.x]` in `build.yml` and `22.x` in `npm.yml`
- `engines.node` in `package.json`, still `^22 || ^24 || ^26`

No `package.json`, lockfile, or source changes.

## Verification

Both workflows parse as valid YAML with the expected step graph, and `grep -rn "actions/[a-z-]*@v[1-4]" .github/` now returns nothing, so no stale pin is left behind to re-trigger the warning.

This PR's own CI run exercises the `build.yml` change directly. The `npm.yml` change cannot be verified until the next release; it is the same two-line edit applied to both of its jobs, and `workflow_dispatch` is available on that workflow if you want to smoke-test it against an existing tag first.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkpmNS8Uw3JgmTQ2iexKXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkpmNS8Uw3JgmTQ2iexKXF)_